### PR TITLE
feat: Implement `get_schema` in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,129 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
 name = "sentry_kafka_schemas"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_yaml",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb06d4b6cdaef0e0c51fa881acb721bed3c924cfaa71d9c94a3b771dfdf6567"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2021"
 path = "rust/lib.rs"
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"]}
+serde_json = "1.0"
+serde_yaml = "0.9"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ clean:
 python/sentry_kafka_schemas/schema_types: schemas/ topics/
 	pip install -r python/requirements-build.txt
 	# the script also imports the python library, so dependencies need to be preinstalled
-	pip install -r python/requirements.txt  
+	pip install -r python/requirements.txt
 	python python/generate_python_types.py
 
 build: python/sentry_kafka_schemas/schema_types
@@ -28,6 +28,7 @@ types: type-checking
 lint:
 	flake8 tests/ python/
 	black --check tests/ python/
+	cargo clippy -- -W clippy::pedantic
 
 tests:
 	pytest tests/ python/ -vv

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -70,6 +70,9 @@ pub struct Schema {
     schema: String,
 }
 
+/// # Errors
+///
+/// Will return `Err` if `topic` or `version` is not found or if schema data is invalid.
 pub fn get_schema(topic: &str, _version: Option<u16>) -> Result<Schema, SchemaError> {
     let topic_path = format!("./topics/{}.yaml", topic);
     let mut topic_data = TopicData::load(&topic_path)?;

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1,8 +1,92 @@
-#[derive(PartialEq, Debug)]
-pub struct Schema {}
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::fs::{read_to_string, File};
 
-pub fn get_schema(topic: &str, version: Option<u16>) -> Option<Schema> {
-    None
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+enum SchemaType {
+    #[serde(rename = "json")]
+    Json,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+enum CompatibilityMode {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "backward")]
+    Backward,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SchemaError {
+    TopicNotFound,
+    InvalidVersion,
+    InvalidType,
+}
+
+impl fmt::Display for SchemaError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SchemaError::TopicNotFound => write!(f, "Topic not found"),
+            SchemaError::InvalidVersion => write!(f, "Invalid version"),
+            SchemaError::InvalidType => write!(f, "Invalid type"),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct TopicSchema {
+    version: u16,
+    #[serde(rename = "type")]
+    schema_type: SchemaType,
+    compatibility_mode: CompatibilityMode,
+    resource: String,
+    examples: Vec<String>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct TopicData {
+    topic: String,
+    schemas: Vec<TopicSchema>,
+}
+
+impl TopicData {
+    fn load(path: &str) -> Result<Self, SchemaError> {
+        let f = File::open(path).map_err(|_| SchemaError::TopicNotFound)?;
+        serde_yaml::from_reader(f).map_err(|_| SchemaError::TopicNotFound)
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Schema {
+    version: u16,
+    schema_type: SchemaType,
+    compatibility_mode: CompatibilityMode,
+    // TODO: Actually parse the json schema
+    schema: String,
+}
+
+pub fn get_schema(topic: &str, _version: Option<u16>) -> Result<Schema, SchemaError> {
+    let topic_path = format!("./topics/{}.yaml", topic);
+    let topic_data = TopicData::load(&topic_path)?;
+    // TODO: Respect version
+    let latest = topic_data.schemas.last().unwrap();
+    if latest.schema_type != SchemaType::Json {
+        return Err(SchemaError::InvalidType);
+    }
+
+    let json_schema_path = format!("./schemas/{}", latest.resource);
+
+    Ok({
+        Schema {
+            version: latest.version,
+            schema_type: latest.schema_type.clone(),
+            compatibility_mode: latest.compatibility_mode.clone(),
+            schema: read_to_string(json_schema_path).unwrap(),
+        }
+    })
 }
 
 #[cfg(test)]
@@ -11,6 +95,9 @@ mod tests {
 
     #[test]
     fn test_get_schema() {
-        assert_eq!(get_schema("asdf", None), None);
+        assert_eq!(get_schema("asdf", None), Err(SchemaError::TopicNotFound));
+        let schema = get_schema("querylog", None).unwrap();
+        assert_eq!(schema.version, 1);
+        assert_eq!(schema.schema_type, SchemaType::Json);
     }
 }

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -72,7 +72,10 @@ pub fn get_schema(topic: &str, _version: Option<u16>) -> Result<Schema, SchemaEr
     let topic_path = format!("./topics/{}.yaml", topic);
     let topic_data = TopicData::load(&topic_path)?;
     // TODO: Respect version
-    let latest = topic_data.schemas.last().unwrap();
+    let latest = topic_data
+        .schemas
+        .last()
+        .ok_or(SchemaError::InvalidVersion)?;
     if latest.schema_type != SchemaType::Json {
         return Err(SchemaError::InvalidType);
     }


### PR DESCRIPTION
Basic rust implementation. Doesn't handle schema versions or parsing json schemas yet.