### PR TITLE
fix(ci): Bump timeout of linter job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   linting:
     name: "Run linters"
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
         name: Checkout code


### PR DESCRIPTION
https://github.com/getsentry/sentry-kafka-schemas/commit/84545fef6de110ccfc8db3c4fb9cd49fd1e9f51e added something to `make lint`, and as a result the lint job in main branch timed out.
