### PR TITLE
fix: Enforce minimum required on typing-extensions

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,3 @@
 python-rapidjson==1.8
 PyYAML==6.0
-typing-extensions
+typing-extensions>=4.0.0


### PR DESCRIPTION
At first I thought we should not pin this version at all because surely
people will have it pinned themselves in apps, but we should at least
rqeuire a version that contains the `Required` we use.
