### PR TITLE
fix: Another instance of nullable tags

### DIFF
--- a/examples/events/1/null-tag-keys.json
+++ b/examples/events/1/null-tag-keys.json
@@ -26,6 +26,7 @@
       "environment": "production",
       "contexts": {},
       "tags": [
+        null,
         [
           null,
           "redacted"

--- a/schemas/events.v1.schema.json
+++ b/schemas/events.v1.schema.json
@@ -2707,7 +2707,8 @@
           ],
           "maxItems": 2,
           "minItems": 2
-        }
+        },
+        {"type": "null"}
       ]
     },
     "Tags": {


### PR DESCRIPTION
Not sure why this one is still happening, I thought that at some point I
did changes to Relay so it won't. In the payload i've seen there's also
no _meta. So I think this is the SDK posting garbage.
