### PR TITLE
ref: Bump jsonschema-gentypes

### DIFF
--- a/python/generate_python_types.py
+++ b/python/generate_python_types.py
@@ -35,9 +35,7 @@ def run(target_folder: str = "python/sentry_kafka_schemas/schema_types/") -> Non
                     "--json-schema",
                     schema_data["schema_filepath"],
                     "--python",
-                    os.path.join(target_folder, f"{schema_tmp_module_name}.py"),
-                    "--rewrite-import",
-                    "typing.Required:typing_extensions",
+                    os.path.join(target_folder, f"{schema_tmp_module_name}.py")
                 ]
             )
 

--- a/python/generate_python_types.py
+++ b/python/generate_python_types.py
@@ -35,7 +35,7 @@ def run(target_folder: str = "python/sentry_kafka_schemas/schema_types/") -> Non
                     "--json-schema",
                     schema_data["schema_filepath"],
                     "--python",
-                    os.path.join(target_folder, f"{schema_tmp_module_name}.py")
+                    os.path.join(target_folder, f"{schema_tmp_module_name}.py"),
                 ]
             )
 

--- a/python/requirements-build.txt
+++ b/python/requirements-build.txt
@@ -1,1 +1,1 @@
-jsonschema-gentypes @ https://github.com/getsentry/jsonschema-gentypes/archive/f67e1b8b0cf6331cd13c1a0396c981f934f05e10.zip
+jsonschema-gentypes==1.5.0


### PR DESCRIPTION
Upstream changes have been merged and released.

jsonschema-gentypes now uses the current Python version (in our case
Python 3.8) to determine which imports to rewrite.
