### PR TITLE
build: pyyaml>=5.4,<7.0

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,3 @@
 python-rapidjson==1.8
-PyYAML==6.0
+PyYAML>=5.4,<7.0
 typing-extensions>=4.0.0


### PR DESCRIPTION
Because sentry uses pyyaml 5.4