### PR TITLE
feat: Add ingest-metrics topic

### DIFF
--- a/examples/ingest-metrics/1/basic-counter.json
+++ b/examples/ingest-metrics/1/basic-counter.json
@@ -1,0 +1,16 @@
+{
+    "org_id": 420,
+    "project_id": 420,
+    "name": "c:sessions/session@none",
+    "tags": {
+        "sdk": "raven-node/2.6.3",
+        "environment": "production",
+        "release": "sentry-test@1.0.0",
+        "session.status": "init"
+    },
+    "timestamp": 1111111111111111,
+    "retention_days": 90,
+    "width": 1,
+    "type": "c",
+    "value": 1
+}

--- a/examples/ingest-metrics/1/basic-counter.json
+++ b/examples/ingest-metrics/1/basic-counter.json
@@ -1,16 +1,16 @@
 {
-    "org_id": 420,
-    "project_id": 420,
-    "name": "c:sessions/session@none",
-    "tags": {
-        "sdk": "raven-node/2.6.3",
-        "environment": "production",
-        "release": "sentry-test@1.0.0",
-        "session.status": "init"
-    },
-    "timestamp": 1111111111111111,
-    "retention_days": 90,
-    "width": 1,
-    "type": "c",
-    "value": 1
+  "org_id": 420,
+  "project_id": 420,
+  "name": "c:sessions/session@none",
+  "tags": {
+    "sdk": "raven-node/2.6.3",
+    "environment": "production",
+    "release": "sentry-test@1.0.0",
+    "session.status": "init"
+  },
+  "timestamp": 1111111111111111,
+  "retention_days": 90,
+  "width": 1,
+  "type": "c",
+  "value": 1
 }

--- a/examples/ingest-metrics/1/basic-distribution.json
+++ b/examples/ingest-metrics/1/basic-distribution.json
@@ -1,10 +1,10 @@
 {
-    "name": "d:transactions/duration@millisecond",
-    "org_id": 1,
-    "retention_days": 90,
-    "project_id": 42,
-    "tags": {},
-    "type": "d",
-    "value": [1.0, 2.0, 3.0],
-    "timestamp": 666666666666  
+  "name": "d:transactions/duration@millisecond",
+  "org_id": 1,
+  "retention_days": 90,
+  "project_id": 42,
+  "tags": {},
+  "type": "d",
+  "value": [1.0, 2.0, 3.0],
+  "timestamp": 666666666666
 }

--- a/examples/ingest-metrics/1/basic-distribution.json
+++ b/examples/ingest-metrics/1/basic-distribution.json
@@ -1,0 +1,10 @@
+{
+    "name": "d:transactions/duration@millisecond",
+    "org_id": 1,
+    "retention_days": 90,
+    "project_id": 42,
+    "tags": {},
+    "type": "d",
+    "value": [1.0, 2.0, 3.0],
+    "timestamp": 666666666666  
+}

--- a/examples/ingest-metrics/1/basic-set.json
+++ b/examples/ingest-metrics/1/basic-set.json
@@ -1,0 +1,15 @@
+{
+    "org_id": 420,
+    "project_id": 420,
+    "name": "s:sessions/user@none",
+    "tags": {
+        "sdk": "raven-node/2.6.3",
+        "environment": "production",
+        "release": "sentry-test@1.0.0"
+    },
+    "timestamp": 11111111111,
+    "width": 1,
+    "type": "s",
+    "retention_days": 90,
+    "value": [1617781333]
+}

--- a/examples/ingest-metrics/1/basic-set.json
+++ b/examples/ingest-metrics/1/basic-set.json
@@ -1,15 +1,15 @@
 {
-    "org_id": 420,
-    "project_id": 420,
-    "name": "s:sessions/user@none",
-    "tags": {
-        "sdk": "raven-node/2.6.3",
-        "environment": "production",
-        "release": "sentry-test@1.0.0"
-    },
-    "timestamp": 11111111111,
-    "width": 1,
-    "type": "s",
-    "retention_days": 90,
-    "value": [1617781333]
+  "org_id": 420,
+  "project_id": 420,
+  "name": "s:sessions/user@none",
+  "tags": {
+    "sdk": "raven-node/2.6.3",
+    "environment": "production",
+    "release": "sentry-test@1.0.0"
+  },
+  "timestamp": 11111111111,
+  "width": 1,
+  "type": "s",
+  "retention_days": 90,
+  "value": [1617781333]
 }

--- a/schemas/ingest-metrics.v1.schema.json
+++ b/schemas/ingest-metrics.v1.schema.json
@@ -65,11 +65,8 @@
     },
     "StringToString": {
       "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^.*$": {
+      "additionalProperties": {
           "type": "string"
-        }
       }
     }
   }

--- a/schemas/ingest-metrics.v1.schema.json
+++ b/schemas/ingest-metrics.v1.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Main",
+  "definitions": {
+    "Main": {
+      "type": "object",
+      "title": "ingest_metric",
+      "additionalProperties": false,
+      "properties": {
+        "org_id": {
+        "description": "The organization for which this metric is being sent.",
+          "type": "integer"
+        },
+        "project_id": {
+            "description": "The project for which this metric is being sent.",
+          "type": "integer"
+        },
+        "name": {
+            "description": "The metric name. Relay sometimes calls this an MRI and makes assumptions about its string shape, and those assumptions also exist in certain queries. The rest of the ingestion pipeline treats it as an opaque string.",
+          "type": "string"
+        },
+        "type": {
+            "description": "The metric type. [c]ounter, [d]istribution, [s]et. Relay additionally defines Gauge, but that metric type is completely unsupported downstream.",
+            "type": "string",
+            "pattern": "^[cds]$"
+        },
+        "timestamp": {
+            "description": "The timestamp at which this metric was being sent. Relay will round this down to the next 10-second interval.",
+          "type": "integer"
+        },
+        "tags": {
+          "$ref": "#/definitions/StringToString"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          ]
+        },
+        "width": {
+            "description": "DEAD PARAMETER -- downstream consumers do not use this, but relay sends it anyway. should remove or actually use",
+            "type": "integer"
+        },
+        "retention_days": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name",
+        "org_id",
+        "project_id",
+        "retention_days",
+        "tags",
+        "timestamp",
+        "type",
+        "value"
+      ]
+    },
+    "StringToString": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^.*$": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/schemas/ingest-metrics.v1.schema.json
+++ b/schemas/ingest-metrics.v1.schema.json
@@ -8,24 +8,24 @@
       "additionalProperties": false,
       "properties": {
         "org_id": {
-        "description": "The organization for which this metric is being sent.",
+          "description": "The organization for which this metric is being sent.",
           "type": "integer"
         },
         "project_id": {
-            "description": "The project for which this metric is being sent.",
+          "description": "The project for which this metric is being sent.",
           "type": "integer"
         },
         "name": {
-            "description": "The metric name. Relay sometimes calls this an MRI and makes assumptions about its string shape, and those assumptions also exist in certain queries. The rest of the ingestion pipeline treats it as an opaque string.",
+          "description": "The metric name. Relay sometimes calls this an MRI and makes assumptions about its string shape, and those assumptions also exist in certain queries. The rest of the ingestion pipeline treats it as an opaque string.",
           "type": "string"
         },
         "type": {
-            "description": "The metric type. [c]ounter, [d]istribution, [s]et. Relay additionally defines Gauge, but that metric type is completely unsupported downstream.",
-            "type": "string",
-            "pattern": "^[cds]$"
+          "description": "The metric type. [c]ounter, [d]istribution, [s]et. Relay additionally defines Gauge, but that metric type is completely unsupported downstream.",
+          "type": "string",
+          "pattern": "^[cds]$"
         },
         "timestamp": {
-            "description": "The timestamp at which this metric was being sent. Relay will round this down to the next 10-second interval.",
+          "description": "The timestamp at which this metric was being sent. Relay will round this down to the next 10-second interval.",
           "type": "integer"
         },
         "tags": {
@@ -45,8 +45,8 @@
           ]
         },
         "width": {
-            "description": "DEAD PARAMETER -- downstream consumers do not use this, but relay sends it anyway. should remove or actually use",
-            "type": "integer"
+          "description": "DEAD PARAMETER -- downstream consumers do not use this, but relay sends it anyway. should remove or actually use",
+          "type": "integer"
         },
         "retention_days": {
           "type": "integer"
@@ -66,7 +66,7 @@
     "StringToString": {
       "type": "object",
       "additionalProperties": {
-          "type": "string"
+        "type": "string"
       }
     }
   }

--- a/schemas/snuba-generic-metrics.v1.schema.json
+++ b/schemas/snuba-generic-metrics.v1.schema.json
@@ -83,7 +83,7 @@
     "StringToString": {
       "type": "object",
       "additionalProperties": {
-          "type": "string"
+        "type": "string"
       }
     }
   }

--- a/schemas/snuba-generic-metrics.v1.schema.json
+++ b/schemas/snuba-generic-metrics.v1.schema.json
@@ -82,11 +82,8 @@
     },
     "StringToString": {
       "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^.*$": {
+      "additionalProperties": {
           "type": "string"
-        }
       }
     }
   }

--- a/topics/ingest-metrics.yaml
+++ b/topics/ingest-metrics.yaml
@@ -1,0 +1,9 @@
+topic: ingest-metrics
+description: Both release health and performance metrics (before indexer)
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: json
+    resource: ingest-metrics.v1.schema.json
+    examples:
+      - ingest-metrics/1/


### PR DESCRIPTION
ingest-metrics is technically two topics, but Relay treats it as one. The messages are shaped exactly the same.
