### PR TITLE
feat: Release rust library

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -6,5 +6,6 @@ changelogPolicy: auto
 targets:
   - name: github
   - name: pypi
+  - name: crates
   - name: sentry-pypi
     internalPypiRepo: getsentry/pypi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "sentry-kafka-schemas"
 authors = ["Sentry <oss@sentry.io>"]
 description = "Kafka topics and schemas for Sentry"
 license-file = "./LICENSE"
-version = "0.1.0"
+version = "0.0.16"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -14,3 +14,4 @@ function replace() {
 }
 
 replace "version=\"[0-9.]+\"" "version=\"$NEW_VERSION\"" ./setup.py
+replace "^version = \".*?\"" "version = \"$NEW_VERSION\"" Cargo.toml


### PR DESCRIPTION
Bring Rust library version up to speed with current version, add crates
target to craft

Next Release will then push to crates.io
