### PR TITLE
fix: Fix filename handling of jsonschema changes

### DIFF
--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -64,12 +64,14 @@ def main() -> None:
         print_change(change)
 
     if not non_breaking_changes and not breaking_changes:
-        print("""\
+        print(
+            """\
 There were changes to the JSON schema file, but we couldn't categorize any of
 them. Therefore we don't know whether this change is safe to make.
 
 This might be a gap in linting. Want to take a look at
-https://github.com/getsentry/json-schema-diff/ and figure it out?""")
+https://github.com/getsentry/json-schema-diff/ and figure it out?"""
+        )
         if "--no-exit-code" not in sys.argv:
             sys.exit(2)
 

--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -25,6 +25,9 @@ def main() -> None:
     breaking_changes = []
     non_breaking_changes = []
 
+    if not lines:
+        return
+
     for filename in lines:
         print(f"# {filename}")
         print()

--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -63,6 +63,16 @@ def main() -> None:
     for change in non_breaking_changes:
         print_change(change)
 
+    if not non_breaking_changes and not breaking_changes:
+        print("""\
+There were changes to the JSON schema file, but we couldn't categorize any of
+them. Therefore we don't know whether this change is safe to make.
+
+This might be a gap in linting. Want to take a look at
+https://github.com/getsentry/json-schema-diff/ and figure it out?""")
+        if "--no-exit-code" not in sys.argv:
+            sys.exit(2)
+
     if breaking_changes and "--no-exit-code" not in sys.argv:
         sys.exit(2)
 

--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -26,6 +26,9 @@ def main() -> None:
     non_breaking_changes = []
 
     for filename in lines:
+        print(f"# {filename}")
+        print()
+
         with tempfile.NamedTemporaryFile() as old_file:
             old_file_contents = subprocess.check_output(
                 ["git", "show", f"origin/main:{filename}"]
@@ -38,7 +41,6 @@ def main() -> None:
             ).splitlines():
 
                 change = json.loads(raw_change)
-                change['filename'] = filename
                 if change["is_breaking"]:
                     breaking_changes.append(change)
                 else:
@@ -80,7 +82,7 @@ def print_change(change: Change) -> None:
 
     printer = _CHANGE_PRINTERS.get(next(iter(change["change"])))
     if printer:
-        print(f"# {printer(change)}")
+        print(f"## {printer(change)}")
 
     print(json.dumps(change))
     print()

--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -26,9 +26,6 @@ def main() -> None:
     non_breaking_changes = []
 
     for filename in lines:
-        print(f"# {filename}")
-        print()
-
         with tempfile.NamedTemporaryFile() as old_file:
             old_file_contents = subprocess.check_output(
                 ["git", "show", f"origin/main:{filename}"]
@@ -41,6 +38,7 @@ def main() -> None:
             ).splitlines():
 
                 change = json.loads(raw_change)
+                change['filename'] = filename
                 if change["is_breaking"]:
                     breaking_changes.append(change)
                 else:
@@ -82,7 +80,7 @@ def print_change(change: Change) -> None:
 
     printer = _CHANGE_PRINTERS.get(next(iter(change["change"])))
     if printer:
-        print(f"## {printer(change)}")
+        print(f"# {printer(change)}")
 
     print(json.dumps(change))
     print()


### PR DESCRIPTION
The script is not supposed to print anything if there are no changes.

Instead, it prints all changed files right now, such as in https://github.com/getsentry/sentry-kafka-schemas/pull/69

Let's just get rid of filename headers for now and add them to the
"change object"
