### PR TITLE
fix: Remove incorrect property from subscription result schema

### DIFF
--- a/schemas/subscription-results.v1.schema.json
+++ b/schemas/subscription-results.v1.schema.json
@@ -46,9 +46,6 @@
                     "additionalProperties": false
                   }
                 },
-                "totals": {
-                  "type": "object"
-                },
                 "profile": {
                   "type": ["object", "null"]
                 },


### PR DESCRIPTION
This is never actually included in the message, only used internally in Snuba. The property is not present on the example either.