### PR TITLE
feat: Transactions topic and schema definition

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,7 @@
 
 # Topics consumed by Snuba
 /topics/events.yaml                                        @getsentry/owners-snuba
+/topics/transactions.yaml                                  @getsentry/owners-snuba
 /topics/outcomes.yaml                                      @getsentry/owners-snuba
 /topics/snuba-metrics.yaml                                 @getsentry/owners-snuba
 /topics/snuba-generic-metrics.yaml                         @getsentry/owners-snuba

--- a/examples/transactions/1/basic_insert_dev.json
+++ b/examples/transactions/1/basic_insert_dev.json
@@ -3,7 +3,7 @@
   "insert",
   {
     "group_id": null,
-  "group_ids": [],
+    "group_ids": [],
     "event_id": "dcc403b73ef548648188bbfa6012e9dc",
     "organization_id": 1,
     "project_id": 1,

--- a/examples/transactions/1/basic_insert_dev.json
+++ b/examples/transactions/1/basic_insert_dev.json
@@ -1,0 +1,207 @@
+[
+  2,
+  "insert",
+  {
+    "group_id": null,
+  "group_ids": [],
+    "event_id": "dcc403b73ef548648188bbfa6012e9dc",
+    "organization_id": 1,
+    "project_id": 1,
+    "message": "sentry.monitors.tasks.check_monitors",
+    "platform": "python",
+    "datetime": "2023-03-29T23:39:23.188890Z",
+    "data": {
+      "event_id": "dcc403b73ef548648188bbfa6012e9dc",
+      "level": "info",
+      "version": "7",
+      "type": "transaction",
+      "transaction": "sentry.monitors.tasks.check_monitors",
+      "transaction_info": { "source": "task" },
+      "logger": "",
+      "platform": "python",
+      "timestamp": 1680133163.18889,
+      "start_timestamp": 1680133163.150449,
+      "received": 1680133163.233106,
+      "release": "backend@23.4.0.dev0+ea9e2e29653c5eb60741d68a1220657e24609eeb",
+      "environment": "development",
+      "contexts": {
+        "runtime": {
+          "name": "CPython",
+          "version": "3.8.13",
+          "build": "3.8.13 (default, Jul 25 2022, 16:52:16) \n[Clang 13.1.6 (clang-1316.0.21.2.5)]",
+          "type": "runtime"
+        },
+        "trace": {
+          "trace_id": "a1f6d1d2c9a24669bd3b530806c12094",
+          "span_id": "a887fb1496e1057f",
+          "parent_span_id": "b7a85c83b3077daa",
+          "op": "queue.task.celery",
+          "status": "ok",
+          "exclusive_time": 5.002,
+          "type": "trace",
+          "hash": "fe0f374c5e6d2b97"
+        }
+      },
+      "tags": [
+        ["celery_task_id", "07619167-85ac-428c-8960-6f3e66d942ac"],
+        ["spans_over_limit", "False"],
+        ["status", "ok"],
+        ["task_name", "sentry.monitors.tasks.check_monitors"],
+        ["transaction_id", null],
+        ["server_name", "Lyns-MacBook-Pro-13"],
+        ["level", "info"],
+        ["environment", "development"],
+        ["transaction", "sentry.monitors.tasks.check_monitors"],
+        [
+          "sentry:release",
+          "backend@23.4.0.dev0+ea9e2e29653c5eb60741d68a1220657e24609eeb"
+        ],
+        ["runtime", "CPython 3.8.13"],
+        ["runtime.name", "CPython"]
+      ],
+      "extra": {
+        "celery-job": {
+          "args": [],
+          "kwargs": {},
+          "task_name": "sentry.monitors.tasks.check_monitors"
+        },
+        "sys.argv": [
+          "/Users/lyn/Code/sentry/.venv/bin/sentry",
+          "run",
+          "worker",
+          "-c",
+          "1",
+          "--autoreload"
+        ]
+      },
+      "sdk": {
+        "name": "sentry.python.django",
+        "version": "1.17.0",
+        "integrations": [
+          "argv",
+          "atexit",
+          "celery",
+          "dedupe",
+          "django",
+          "django_atomic",
+          "excepthook",
+          "logging",
+          "modules",
+          "redis",
+          "rust_info",
+          "stdlib",
+          "threading"
+        ],
+        "packages": [{ "name": "pypi:sentry-sdk", "version": "1.17.0" }]
+      },
+      "key_id": "1",
+      "project": 1,
+      "grouping_config": {
+        "enhancements": "eJybzDRxY3J-bm5-npWRgaGlroGxrpHxBABcYgcZ",
+        "id": "newstyle:2019-10-29"
+      },
+      "spans": [
+        {
+          "timestamp": 1680133163.173439,
+          "start_timestamp": 1680133163.152112,
+          "exclusive_time": 21.327,
+          "description": "connect",
+          "op": "db",
+          "span_id": "a4137e586e0b6813",
+          "parent_span_id": "a887fb1496e1057f",
+          "trace_id": "a1f6d1d2c9a24669bd3b530806c12094",
+          "same_process_as_parent": true,
+          "tags": null,
+          "data": null,
+          "hash": "b640a0ce465fa2a4"
+        },
+        {
+          "timestamp": 1680133163.17915,
+          "start_timestamp": 1680133163.17366,
+          "exclusive_time": 5.49,
+          "description": "SELECT COUNT(*) FROM (SELECT \"sentry_monitor\".\"id\" AS Col1 FROM \"sentry_monitor\" WHERE (\"sentry_monitor\".\"next_checkin\" < %s AND \"sentry_monitor\".\"type\" IN (%s) AND NOT (\"sentry_monitor\".\"status\" IN (%s, %s, %s)))  LIMIT 10000) subquery",
+          "op": "db",
+          "span_id": "bae9c80bc19f8d65",
+          "parent_span_id": "a887fb1496e1057f",
+          "trace_id": "a1f6d1d2c9a24669bd3b530806c12094",
+          "same_process_as_parent": true,
+          "tags": null,
+          "data": null,
+          "hash": "66a3916fcab72094"
+        },
+        {
+          "timestamp": 1680133163.181655,
+          "start_timestamp": 1680133163.17977,
+          "exclusive_time": 1.885,
+          "description": "SELECT \"sentry_monitor\".\"id\", \"sentry_monitor\".\"guid\", \"sentry_monitor\".\"slug\", \"sentry_monitor\".\"organization_id\", \"sentry_monitor\".\"project_id\", \"sentry_monitor\".\"name\", \"sentry_monitor\".\"status\", \"sentry_monitor\".\"type\", \"sentry_monitor\".\"config\", \"sentry_monitor\".\"next_checkin\", \"sentry_monitor\".\"last_checkin\", \"sentry_monitor\".\"date_added\" FROM \"sentry_monitor\" WHERE (\"sentry_monitor\".\"next_checkin\" < %s AND \"sentry_monitor\".\"type\" IN (%s) AND NOT (\"sentry_monitor\".\"status\" IN (%s, %s, %s)))  LIMIT 10000",
+          "op": "db",
+          "span_id": "b60a4c240ae4683f",
+          "parent_span_id": "a887fb1496e1057f",
+          "trace_id": "a1f6d1d2c9a24669bd3b530806c12094",
+          "same_process_as_parent": true,
+          "tags": null,
+          "data": null,
+          "hash": "991571719e4cbab7"
+        },
+        {
+          "timestamp": 1680133163.18469,
+          "start_timestamp": 1680133163.182343,
+          "exclusive_time": 2.347,
+          "description": "SELECT COUNT(*) FROM (SELECT \"sentry_monitorcheckin\".\"id\" AS Col1 FROM \"sentry_monitorcheckin\" WHERE \"sentry_monitorcheckin\".\"status\" = %s  LIMIT 10000) subquery",
+          "op": "db",
+          "span_id": "b9e93691deb062f1",
+          "parent_span_id": "a887fb1496e1057f",
+          "trace_id": "a1f6d1d2c9a24669bd3b530806c12094",
+          "same_process_as_parent": true,
+          "tags": null,
+          "data": null,
+          "hash": "e5882920bb02bd9c"
+        },
+        {
+          "timestamp": 1680133163.187818,
+          "start_timestamp": 1680133163.185428,
+          "exclusive_time": 2.39,
+          "description": "SELECT \"sentry_monitorcheckin\".\"id\", \"sentry_monitorcheckin\".\"guid\", \"sentry_monitorcheckin\".\"project_id\", \"sentry_monitorcheckin\".\"monitor_id\", \"sentry_monitorcheckin\".\"monitor_environment_id\", \"sentry_monitorcheckin\".\"location_id\", \"sentry_monitorcheckin\".\"status\", \"sentry_monitorcheckin\".\"config\", \"sentry_monitorcheckin\".\"duration\", \"sentry_monitorcheckin\".\"date_added\", \"sentry_monitorcheckin\".\"date_updated\", \"sentry_monitorcheckin\".\"attachment_id\", \"sentry_monitor\".\"id\", \"sentry_monitor\".\"guid\", \"sentry_monitor\".\"slug\", \"sentry_monitor\".\"organization_id\", \"sentry_monitor\".\"project_id\", \"sentry_monitor\".\"name\", \"sentry_monitor\".\"status\", \"sentry_monitor\".\"type\", \"sentry_monitor\".\"config\", \"sentry_monitor\".\"next_checkin\", \"sentry_monitor\".\"last_checkin\", \"sentry_monitor\".\"date_added\" FROM \"sentry_monitorcheckin\" INNER JOIN \"sentry_monitor\" ON (\"sentry_monitorcheckin\".\"monitor_id\" = \"sentry_monitor\".\"id\") WHERE \"sentry_monitorcheckin\".\"status\" = %s  LIMIT 10000",
+          "op": "db",
+          "span_id": "9e6ca0691868127f",
+          "parent_span_id": "a887fb1496e1057f",
+          "trace_id": "a1f6d1d2c9a24669bd3b530806c12094",
+          "same_process_as_parent": true,
+          "tags": null,
+          "data": null,
+          "hash": "8e56fb346112a315"
+        }
+      ],
+      "measurements": { "num_of_spans": { "value": 5.0, "unit": "none" } },
+      "breakdowns": {
+        "span_ops": {
+          "ops.db": { "value": 33.439, "unit": "millisecond" },
+          "total.time": { "value": 33.439, "unit": "millisecond" }
+        }
+      },
+      "_metrics": { "bytes.ingested.event": 4819, "bytes.stored.event": 6052 },
+      "span_grouping_config": { "id": "default:2022-10-27" },
+      "culprit": "sentry.monitors.tasks.check_monitors",
+      "metadata": {
+        "title": "sentry.monitors.tasks.check_monitors",
+        "location": "sentry.monitors.tasks.check_monitors"
+      },
+      "title": "sentry.monitors.tasks.check_monitors",
+      "location": "sentry.monitors.tasks.check_monitors",
+      "hashes": [],
+      "nodestore_insert": 1680133164.430991
+    },
+    "primary_hash": null,
+    "retention_days": null,
+    "occurrence_id": null,
+    "occurrence_data": {}
+  },
+  {
+    "is_new": false,
+    "is_regression": false,
+    "is_new_group_environment": false,
+    "queue": "post_process_transactions",
+    "skip_consume": false,
+    "group_states": null
+  }
+]

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -3,7 +3,7 @@
   "type": "array",
   "items": [
     { "const": 2 },
-    { "const": 2 },
+    { "const": "insert" },
     {
       "type": "object",
       "properties": {

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -1,20 +1,18 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "array",
-  "items": {
-    "$ref": "#/definitions/TransactionMessage"
-  },
+  "items": [
+    { "const": 2 },
+    { "const": "insert" },
+    {
+      "$ref": "#/definitions/TransactionMessage"
+    }
+  ],
   "definitions": {
     "TransactionMessage": {
       "anyOf": [
         {
           "$ref": "#/definitions/TransactionEvent"
-        },
-        {
-          "type": "integer"
-        },
-        {
-          "type": "string"
         }
       ],
       "title": "transaction_message"

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -339,37 +339,9 @@
       ]
     },
     "Extra": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "celery-job": {
-          "$ref": "#/definitions/CeleryJob"
-        },
-        "sys.argv": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "required": ["celery-job", "sys.argv"]
-    },
-    "CeleryJob": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "args": {
-          "type": "array",
-          "items": {}
-        },
-        "kwargs": {
-          "$ref": "#/definitions/OccurrenceData"
-        },
-        "task_name": {
-          "type": "string"
-        }
-      },
-      "required": ["args", "kwargs", "task_name"]
+      "description": " Arbitrary extra information set by the user.\n\n ```json\n {\n     \"extra\": {\n         \"my_key\": 1,\n         \"some_other_value\": \"foo bar\"\n     }\n }```",
+      "type": ["object", "null"],
+      "additionalProperties": true
     },
     "OccurrenceData": {
       "type": "object",

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -12,7 +12,7 @@
         },
         "group_ids": {
           "type": "array",
-          "items": {}
+          "maxItems": 0
         },
         "event_id": {
           "type": "string"

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -5,18 +5,10 @@
     { "const": 2 },
     { "const": "insert" },
     {
-      "$ref": "#/definitions/TransactionMessage"
+      "$ref": "#/definitions/TransactionEvent"
     }
   ],
   "definitions": {
-    "TransactionMessage": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/TransactionEvent"
-        }
-      ],
-      "title": "transaction_message"
-    },
     "TransactionEvent": {
       "type": "object",
       "title": "transaction_event",
@@ -27,7 +19,7 @@
         },
         "group_ids": {
           "type": "array",
-          "items": {}
+          "maxItems": 0
         },
         "event_id": {
           "type": "string"

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -1,0 +1,898 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": [
+    { "const": 2 },
+    { "const": 2 },
+    {
+      "type": "object",
+      "properties": {
+        "group_id": {
+          "type": "null"
+        },
+        "group_ids": {
+          "type": "array",
+          "items": {}
+        },
+        "event_id": {
+          "type": "string"
+        },
+        "organization_id": {
+          "type": "integer"
+        },
+        "project_id": {
+          "type": "integer"
+        },
+        "message": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        },
+        "datetime": {
+          "type": "string"
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "event_id": {
+              "type": "string"
+            },
+            "level": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "transaction": {
+              "type": "string"
+            },
+            "transaction_info": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "string"
+                }
+              },
+              "required": ["source"]
+            },
+            "logger": {
+              "type": "string"
+            },
+            "platform": {
+              "type": "string"
+            },
+            "timestamp": {
+              "type": "number"
+            },
+            "start_timestamp": {
+              "type": "number"
+            },
+            "received": {
+              "type": "number"
+            },
+            "release": {
+              "type": "string"
+            },
+            "environment": {
+              "type": "string"
+            },
+            "contexts": {
+              "type": "object",
+              "properties": {
+                "runtime": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    },
+                    "build": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["name", "version", "build", "type"]
+                },
+                "trace": {
+                  "type": "object",
+                  "properties": {
+                    "trace_id": {
+                      "type": "string"
+                    },
+                    "span_id": {
+                      "type": "string"
+                    },
+                    "parent_span_id": {
+                      "type": "string"
+                    },
+                    "op": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "exclusive_time": {
+                      "type": "number"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "hash": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "trace_id",
+                    "span_id",
+                    "parent_span_id",
+                    "op",
+                    "status",
+                    "exclusive_time",
+                    "type",
+                    "hash"
+                  ]
+                }
+              },
+              "required": ["runtime", "trace"]
+            },
+            "tags": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              ]
+            },
+            "extra": {
+              "type": "object",
+              "properties": {
+                "celery-job": {
+                  "type": "object",
+                  "properties": {
+                    "args": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "kwargs": {
+                      "type": "object"
+                    },
+                    "task_name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["args", "kwargs", "task_name"]
+                },
+                "sys.argv": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              "required": ["celery-job", "sys.argv"]
+            },
+            "sdk": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                },
+                "integrations": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "packages": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["name", "version"]
+                    }
+                  ]
+                }
+              },
+              "required": ["name", "version", "integrations", "packages"]
+            },
+            "key_id": {
+              "type": "string"
+            },
+            "project": {
+              "type": "integer"
+            },
+            "grouping_config": {
+              "type": "object",
+              "properties": {
+                "enhancements": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                }
+              },
+              "required": ["enhancements", "id"]
+            },
+            "spans": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "timestamp": {
+                      "type": "number"
+                    },
+                    "start_timestamp": {
+                      "type": "number"
+                    },
+                    "exclusive_time": {
+                      "type": "number"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "op": {
+                      "type": "string"
+                    },
+                    "span_id": {
+                      "type": "string"
+                    },
+                    "parent_span_id": {
+                      "type": "string"
+                    },
+                    "trace_id": {
+                      "type": "string"
+                    },
+                    "same_process_as_parent": {
+                      "type": "boolean"
+                    },
+                    "tags": {
+                      "type": "null"
+                    },
+                    "data": {
+                      "type": "null"
+                    },
+                    "hash": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "timestamp",
+                    "start_timestamp",
+                    "exclusive_time",
+                    "description",
+                    "op",
+                    "span_id",
+                    "parent_span_id",
+                    "trace_id",
+                    "same_process_as_parent",
+                    "tags",
+                    "data",
+                    "hash"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "timestamp": {
+                      "type": "number"
+                    },
+                    "start_timestamp": {
+                      "type": "number"
+                    },
+                    "exclusive_time": {
+                      "type": "number"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "op": {
+                      "type": "string"
+                    },
+                    "span_id": {
+                      "type": "string"
+                    },
+                    "parent_span_id": {
+                      "type": "string"
+                    },
+                    "trace_id": {
+                      "type": "string"
+                    },
+                    "same_process_as_parent": {
+                      "type": "boolean"
+                    },
+                    "tags": {
+                      "type": "null"
+                    },
+                    "data": {
+                      "type": "null"
+                    },
+                    "hash": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "timestamp",
+                    "start_timestamp",
+                    "exclusive_time",
+                    "description",
+                    "op",
+                    "span_id",
+                    "parent_span_id",
+                    "trace_id",
+                    "same_process_as_parent",
+                    "tags",
+                    "data",
+                    "hash"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "timestamp": {
+                      "type": "number"
+                    },
+                    "start_timestamp": {
+                      "type": "number"
+                    },
+                    "exclusive_time": {
+                      "type": "number"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "op": {
+                      "type": "string"
+                    },
+                    "span_id": {
+                      "type": "string"
+                    },
+                    "parent_span_id": {
+                      "type": "string"
+                    },
+                    "trace_id": {
+                      "type": "string"
+                    },
+                    "same_process_as_parent": {
+                      "type": "boolean"
+                    },
+                    "tags": {
+                      "type": "null"
+                    },
+                    "data": {
+                      "type": "null"
+                    },
+                    "hash": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "timestamp",
+                    "start_timestamp",
+                    "exclusive_time",
+                    "description",
+                    "op",
+                    "span_id",
+                    "parent_span_id",
+                    "trace_id",
+                    "same_process_as_parent",
+                    "tags",
+                    "data",
+                    "hash"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "timestamp": {
+                      "type": "number"
+                    },
+                    "start_timestamp": {
+                      "type": "number"
+                    },
+                    "exclusive_time": {
+                      "type": "number"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "op": {
+                      "type": "string"
+                    },
+                    "span_id": {
+                      "type": "string"
+                    },
+                    "parent_span_id": {
+                      "type": "string"
+                    },
+                    "trace_id": {
+                      "type": "string"
+                    },
+                    "same_process_as_parent": {
+                      "type": "boolean"
+                    },
+                    "tags": {
+                      "type": "null"
+                    },
+                    "data": {
+                      "type": "null"
+                    },
+                    "hash": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "timestamp",
+                    "start_timestamp",
+                    "exclusive_time",
+                    "description",
+                    "op",
+                    "span_id",
+                    "parent_span_id",
+                    "trace_id",
+                    "same_process_as_parent",
+                    "tags",
+                    "data",
+                    "hash"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "timestamp": {
+                      "type": "number"
+                    },
+                    "start_timestamp": {
+                      "type": "number"
+                    },
+                    "exclusive_time": {
+                      "type": "number"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "op": {
+                      "type": "string"
+                    },
+                    "span_id": {
+                      "type": "string"
+                    },
+                    "parent_span_id": {
+                      "type": "string"
+                    },
+                    "trace_id": {
+                      "type": "string"
+                    },
+                    "same_process_as_parent": {
+                      "type": "boolean"
+                    },
+                    "tags": {
+                      "type": "null"
+                    },
+                    "data": {
+                      "type": "null"
+                    },
+                    "hash": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "timestamp",
+                    "start_timestamp",
+                    "exclusive_time",
+                    "description",
+                    "op",
+                    "span_id",
+                    "parent_span_id",
+                    "trace_id",
+                    "same_process_as_parent",
+                    "tags",
+                    "data",
+                    "hash"
+                  ]
+                }
+              ]
+            },
+            "measurements": {
+              "type": "object",
+              "properties": {
+                "num_of_spans": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "number"
+                    },
+                    "unit": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["value", "unit"]
+                }
+              },
+              "required": ["num_of_spans"]
+            },
+            "breakdowns": {
+              "type": "object",
+              "properties": {
+                "span_ops": {
+                  "type": "object",
+                  "properties": {
+                    "ops.db": {
+                      "type": "object",
+                      "properties": {
+                        "value": {
+                          "type": "number"
+                        },
+                        "unit": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["value", "unit"]
+                    },
+                    "total.time": {
+                      "type": "object",
+                      "properties": {
+                        "value": {
+                          "type": "number"
+                        },
+                        "unit": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["value", "unit"]
+                    }
+                  },
+                  "required": ["ops.db", "total.time"]
+                }
+              },
+              "required": ["span_ops"]
+            },
+            "_metrics": {
+              "type": "object",
+              "properties": {
+                "bytes.ingested.event": {
+                  "type": "integer"
+                },
+                "bytes.stored.event": {
+                  "type": "integer"
+                }
+              },
+              "required": ["bytes.ingested.event", "bytes.stored.event"]
+            },
+            "span_grouping_config": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              },
+              "required": ["id"]
+            },
+            "culprit": {
+              "type": "string"
+            },
+            "metadata": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                }
+              },
+              "required": ["title", "location"]
+            },
+            "title": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            },
+            "hashes": {
+              "type": "array",
+              "items": {}
+            },
+            "nodestore_insert": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "event_id",
+            "level",
+            "version",
+            "type",
+            "transaction",
+            "transaction_info",
+            "logger",
+            "platform",
+            "timestamp",
+            "start_timestamp",
+            "received",
+            "release",
+            "environment",
+            "contexts",
+            "tags",
+            "extra",
+            "sdk",
+            "key_id",
+            "project",
+            "grouping_config",
+            "spans",
+            "measurements",
+            "breakdowns",
+            "_metrics",
+            "span_grouping_config",
+            "culprit",
+            "metadata",
+            "title",
+            "location",
+            "hashes",
+            "nodestore_insert"
+          ]
+        },
+        "primary_hash": {
+          "type": "null"
+        },
+        "retention_days": {
+          "type": "null"
+        },
+        "occurrence_id": {
+          "type": "null"
+        },
+        "occurrence_data": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "group_id",
+        "group_ids",
+        "event_id",
+        "organization_id",
+        "project_id",
+        "message",
+        "platform",
+        "datetime",
+        "data",
+        "primary_hash",
+        "retention_days",
+        "occurrence_id",
+        "occurrence_data"
+      ]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "is_new": {
+          "type": "boolean"
+        },
+        "is_regression": {
+          "type": "boolean"
+        },
+        "is_new_group_environment": {
+          "type": "boolean"
+        },
+        "queue": {
+          "type": "string"
+        },
+        "skip_consume": {
+          "type": "boolean"
+        },
+        "group_states": {
+          "type": "null"
+        }
+      },
+      "required": [
+        "is_new",
+        "is_regression",
+        "is_new_group_environment",
+        "queue",
+        "skip_consume",
+        "group_states"
+      ]
+    }
+  ]
+}

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "transaction",
   "type": "array",
   "items": [
     { "const": 2 },

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -49,7 +49,7 @@
           "type": "null"
         },
         "retention_days": {
-          "type": ["integer", "null"]
+          "type": "null"
         },
         "occurrence_id": {
           "type": "null"
@@ -76,27 +76,7 @@
           "type": "null"
         }
       },
-      "required": [
-        "group_id",
-        "group_ids",
-        "event_id",
-        "organization_id",
-        "project_id",
-        "message",
-        "platform",
-        "datetime",
-        "data",
-        "primary_hash",
-        "retention_days",
-        "occurrence_id",
-        "occurrence_data",
-        "is_new",
-        "is_regression",
-        "is_new_group_environment",
-        "queue",
-        "skip_consume",
-        "group_states"
-      ]
+      "required": []
     },
     "Data": {
       "type": "object",

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -1,19 +1,35 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "transaction",
   "type": "array",
-  "items": [
-    { "const": 2 },
-    { "const": "insert" },
-    {
+  "items": {
+    "$ref": "#/definitions/TransactionMessage"
+  },
+  "definitions": {
+    "TransactionMessage": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TransactionEvent"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "title": "transaction_message"
+    },
+    "TransactionEvent": {
       "type": "object",
+      "title": "transaction_event",
+      "additionalProperties": false,
       "properties": {
         "group_id": {
           "type": "null"
         },
         "group_ids": {
           "type": "array",
-          "maxItems": 0
+          "items": {}
         },
         "event_id": {
           "type": "string"
@@ -31,809 +47,11 @@
           "type": "string"
         },
         "datetime": {
-          "type": "string"
+          "type": "string",
+          "format": "date-time"
         },
         "data": {
-          "type": "object",
-          "properties": {
-            "event_id": {
-              "type": "string"
-            },
-            "level": {
-              "type": "string"
-            },
-            "version": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string"
-            },
-            "transaction": {
-              "type": "string"
-            },
-            "transaction_info": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                }
-              },
-              "required": ["source"]
-            },
-            "logger": {
-              "type": "string"
-            },
-            "platform": {
-              "type": "string"
-            },
-            "timestamp": {
-              "type": "number"
-            },
-            "start_timestamp": {
-              "type": "number"
-            },
-            "received": {
-              "type": "number"
-            },
-            "release": {
-              "type": "string"
-            },
-            "environment": {
-              "type": "string"
-            },
-            "contexts": {
-              "type": "object",
-              "properties": {
-                "runtime": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "version": {
-                      "type": "string"
-                    },
-                    "build": {
-                      "type": "string"
-                    },
-                    "type": {
-                      "type": "string"
-                    }
-                  },
-                  "required": ["name", "version", "build", "type"]
-                },
-                "trace": {
-                  "type": "object",
-                  "properties": {
-                    "trace_id": {
-                      "type": "string"
-                    },
-                    "span_id": {
-                      "type": "string"
-                    },
-                    "parent_span_id": {
-                      "type": "string"
-                    },
-                    "op": {
-                      "type": "string"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "exclusive_time": {
-                      "type": "number"
-                    },
-                    "type": {
-                      "type": "string"
-                    },
-                    "hash": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "trace_id",
-                    "span_id",
-                    "parent_span_id",
-                    "op",
-                    "status",
-                    "exclusive_time",
-                    "type",
-                    "hash"
-                  ]
-                }
-              },
-              "required": ["runtime", "trace"]
-            },
-            "tags": {
-              "type": "array",
-              "items": [
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                }
-              ]
-            },
-            "extra": {
-              "type": "object",
-              "properties": {
-                "celery-job": {
-                  "type": "object",
-                  "properties": {
-                    "args": {
-                      "type": "array",
-                      "items": {}
-                    },
-                    "kwargs": {
-                      "type": "object"
-                    },
-                    "task_name": {
-                      "type": "string"
-                    }
-                  },
-                  "required": ["args", "kwargs", "task_name"]
-                },
-                "sys.argv": {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                }
-              },
-              "required": ["celery-job", "sys.argv"]
-            },
-            "sdk": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                },
-                "integrations": {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                "packages": {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string"
-                        },
-                        "version": {
-                          "type": "string"
-                        }
-                      },
-                      "required": ["name", "version"]
-                    }
-                  ]
-                }
-              },
-              "required": ["name", "version", "integrations", "packages"]
-            },
-            "key_id": {
-              "type": "string"
-            },
-            "project": {
-              "type": "integer"
-            },
-            "grouping_config": {
-              "type": "object",
-              "properties": {
-                "enhancements": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "string"
-                }
-              },
-              "required": ["enhancements", "id"]
-            },
-            "spans": {
-              "type": "array",
-              "items": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "timestamp": {
-                      "type": "number"
-                    },
-                    "start_timestamp": {
-                      "type": "number"
-                    },
-                    "exclusive_time": {
-                      "type": "number"
-                    },
-                    "description": {
-                      "type": "string"
-                    },
-                    "op": {
-                      "type": "string"
-                    },
-                    "span_id": {
-                      "type": "string"
-                    },
-                    "parent_span_id": {
-                      "type": "string"
-                    },
-                    "trace_id": {
-                      "type": "string"
-                    },
-                    "same_process_as_parent": {
-                      "type": "boolean"
-                    },
-                    "tags": {
-                      "type": "null"
-                    },
-                    "data": {
-                      "type": "null"
-                    },
-                    "hash": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "timestamp",
-                    "start_timestamp",
-                    "exclusive_time",
-                    "description",
-                    "op",
-                    "span_id",
-                    "parent_span_id",
-                    "trace_id",
-                    "same_process_as_parent",
-                    "tags",
-                    "data",
-                    "hash"
-                  ]
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "timestamp": {
-                      "type": "number"
-                    },
-                    "start_timestamp": {
-                      "type": "number"
-                    },
-                    "exclusive_time": {
-                      "type": "number"
-                    },
-                    "description": {
-                      "type": "string"
-                    },
-                    "op": {
-                      "type": "string"
-                    },
-                    "span_id": {
-                      "type": "string"
-                    },
-                    "parent_span_id": {
-                      "type": "string"
-                    },
-                    "trace_id": {
-                      "type": "string"
-                    },
-                    "same_process_as_parent": {
-                      "type": "boolean"
-                    },
-                    "tags": {
-                      "type": "null"
-                    },
-                    "data": {
-                      "type": "null"
-                    },
-                    "hash": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "timestamp",
-                    "start_timestamp",
-                    "exclusive_time",
-                    "description",
-                    "op",
-                    "span_id",
-                    "parent_span_id",
-                    "trace_id",
-                    "same_process_as_parent",
-                    "tags",
-                    "data",
-                    "hash"
-                  ]
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "timestamp": {
-                      "type": "number"
-                    },
-                    "start_timestamp": {
-                      "type": "number"
-                    },
-                    "exclusive_time": {
-                      "type": "number"
-                    },
-                    "description": {
-                      "type": "string"
-                    },
-                    "op": {
-                      "type": "string"
-                    },
-                    "span_id": {
-                      "type": "string"
-                    },
-                    "parent_span_id": {
-                      "type": "string"
-                    },
-                    "trace_id": {
-                      "type": "string"
-                    },
-                    "same_process_as_parent": {
-                      "type": "boolean"
-                    },
-                    "tags": {
-                      "type": "null"
-                    },
-                    "data": {
-                      "type": "null"
-                    },
-                    "hash": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "timestamp",
-                    "start_timestamp",
-                    "exclusive_time",
-                    "description",
-                    "op",
-                    "span_id",
-                    "parent_span_id",
-                    "trace_id",
-                    "same_process_as_parent",
-                    "tags",
-                    "data",
-                    "hash"
-                  ]
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "timestamp": {
-                      "type": "number"
-                    },
-                    "start_timestamp": {
-                      "type": "number"
-                    },
-                    "exclusive_time": {
-                      "type": "number"
-                    },
-                    "description": {
-                      "type": "string"
-                    },
-                    "op": {
-                      "type": "string"
-                    },
-                    "span_id": {
-                      "type": "string"
-                    },
-                    "parent_span_id": {
-                      "type": "string"
-                    },
-                    "trace_id": {
-                      "type": "string"
-                    },
-                    "same_process_as_parent": {
-                      "type": "boolean"
-                    },
-                    "tags": {
-                      "type": "null"
-                    },
-                    "data": {
-                      "type": "null"
-                    },
-                    "hash": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "timestamp",
-                    "start_timestamp",
-                    "exclusive_time",
-                    "description",
-                    "op",
-                    "span_id",
-                    "parent_span_id",
-                    "trace_id",
-                    "same_process_as_parent",
-                    "tags",
-                    "data",
-                    "hash"
-                  ]
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "timestamp": {
-                      "type": "number"
-                    },
-                    "start_timestamp": {
-                      "type": "number"
-                    },
-                    "exclusive_time": {
-                      "type": "number"
-                    },
-                    "description": {
-                      "type": "string"
-                    },
-                    "op": {
-                      "type": "string"
-                    },
-                    "span_id": {
-                      "type": "string"
-                    },
-                    "parent_span_id": {
-                      "type": "string"
-                    },
-                    "trace_id": {
-                      "type": "string"
-                    },
-                    "same_process_as_parent": {
-                      "type": "boolean"
-                    },
-                    "tags": {
-                      "type": "null"
-                    },
-                    "data": {
-                      "type": "null"
-                    },
-                    "hash": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "timestamp",
-                    "start_timestamp",
-                    "exclusive_time",
-                    "description",
-                    "op",
-                    "span_id",
-                    "parent_span_id",
-                    "trace_id",
-                    "same_process_as_parent",
-                    "tags",
-                    "data",
-                    "hash"
-                  ]
-                }
-              ]
-            },
-            "measurements": {
-              "type": "object",
-              "properties": {
-                "num_of_spans": {
-                  "type": "object",
-                  "properties": {
-                    "value": {
-                      "type": "number"
-                    },
-                    "unit": {
-                      "type": "string"
-                    }
-                  },
-                  "required": ["value", "unit"]
-                }
-              },
-              "required": ["num_of_spans"]
-            },
-            "breakdowns": {
-              "type": "object",
-              "properties": {
-                "span_ops": {
-                  "type": "object",
-                  "properties": {
-                    "ops.db": {
-                      "type": "object",
-                      "properties": {
-                        "value": {
-                          "type": "number"
-                        },
-                        "unit": {
-                          "type": "string"
-                        }
-                      },
-                      "required": ["value", "unit"]
-                    },
-                    "total.time": {
-                      "type": "object",
-                      "properties": {
-                        "value": {
-                          "type": "number"
-                        },
-                        "unit": {
-                          "type": "string"
-                        }
-                      },
-                      "required": ["value", "unit"]
-                    }
-                  },
-                  "required": ["ops.db", "total.time"]
-                }
-              },
-              "required": ["span_ops"]
-            },
-            "_metrics": {
-              "type": "object",
-              "properties": {
-                "bytes.ingested.event": {
-                  "type": "integer"
-                },
-                "bytes.stored.event": {
-                  "type": "integer"
-                }
-              },
-              "required": ["bytes.ingested.event", "bytes.stored.event"]
-            },
-            "span_grouping_config": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                }
-              },
-              "required": ["id"]
-            },
-            "culprit": {
-              "type": "string"
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "location": {
-                  "type": "string"
-                }
-              },
-              "required": ["title", "location"]
-            },
-            "title": {
-              "type": "string"
-            },
-            "location": {
-              "type": "string"
-            },
-            "hashes": {
-              "type": "array",
-              "items": {}
-            },
-            "nodestore_insert": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "event_id",
-            "level",
-            "version",
-            "type",
-            "transaction",
-            "transaction_info",
-            "logger",
-            "platform",
-            "timestamp",
-            "start_timestamp",
-            "received",
-            "release",
-            "environment",
-            "contexts",
-            "tags",
-            "extra",
-            "sdk",
-            "key_id",
-            "project",
-            "grouping_config",
-            "spans",
-            "measurements",
-            "breakdowns",
-            "_metrics",
-            "span_grouping_config",
-            "culprit",
-            "metadata",
-            "title",
-            "location",
-            "hashes",
-            "nodestore_insert"
-          ]
+          "$ref": "#/definitions/Data"
         },
         "primary_hash": {
           "type": "null"
@@ -845,28 +63,8 @@
           "type": "null"
         },
         "occurrence_data": {
-          "type": "object"
-        }
-      },
-      "required": [
-        "group_id",
-        "group_ids",
-        "event_id",
-        "organization_id",
-        "project_id",
-        "message",
-        "platform",
-        "datetime",
-        "data",
-        "primary_hash",
-        "retention_days",
-        "occurrence_id",
-        "occurrence_data"
-      ]
-    },
-    {
-      "type": "object",
-      "properties": {
+          "$ref": "#/definitions/OccurrenceData"
+        },
         "is_new": {
           "type": "boolean"
         },
@@ -886,14 +84,454 @@
           "type": "null"
         }
       },
+      "required": []
+    },
+    "Data": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "event_id": {
+          "type": "string"
+        },
+        "level": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "transaction": {
+          "type": "string"
+        },
+        "transaction_info": {
+          "$ref": "#/definitions/TransactionInfo"
+        },
+        "logger": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "start_timestamp": {
+          "type": "number"
+        },
+        "received": {
+          "type": "number"
+        },
+        "release": {
+          "type": "string"
+        },
+        "environment": {
+          "type": "string"
+        },
+        "contexts": {
+          "$ref": "#/definitions/Contexts"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        },
+        "extra": {
+          "$ref": "#/definitions/Extra"
+        },
+        "sdk": {
+          "$ref": "#/definitions/SDK"
+        },
+        "key_id": {
+          "type": "string"
+        },
+        "project": {
+          "type": "integer"
+        },
+        "grouping_config": {
+          "$ref": "#/definitions/GroupingConfig"
+        },
+        "spans": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Span"
+          }
+        },
+        "measurements": {
+          "$ref": "#/definitions/Measurements"
+        },
+        "breakdowns": {
+          "$ref": "#/definitions/Breakdowns"
+        },
+        "_metrics": {
+          "$ref": "#/definitions/Metrics"
+        },
+        "span_grouping_config": {
+          "$ref": "#/definitions/SpanGroupingConfig"
+        },
+        "culprit": {
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/definitions/Metadata"
+        },
+        "title": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "hashes": {
+          "type": "array",
+          "items": {}
+        },
+        "nodestore_insert": {
+          "type": "number"
+        }
+      },
       "required": [
-        "is_new",
-        "is_regression",
-        "is_new_group_environment",
-        "queue",
-        "skip_consume",
-        "group_states"
+        "_metrics",
+        "breakdowns",
+        "contexts",
+        "culprit",
+        "environment",
+        "event_id",
+        "extra",
+        "grouping_config",
+        "hashes",
+        "key_id",
+        "level",
+        "location",
+        "logger",
+        "measurements",
+        "metadata",
+        "nodestore_insert",
+        "platform",
+        "project",
+        "received",
+        "release",
+        "sdk",
+        "span_grouping_config",
+        "spans",
+        "start_timestamp",
+        "tags",
+        "timestamp",
+        "title",
+        "transaction",
+        "transaction_info",
+        "type",
+        "version"
       ]
+    },
+    "Metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bytes.ingested.event": {
+          "type": "integer"
+        },
+        "bytes.stored.event": {
+          "type": "integer"
+        }
+      },
+      "required": ["bytes.ingested.event", "bytes.stored.event"]
+    },
+    "Breakdowns": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "span_ops": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/NumOfSpans"
+          }
+        }
+      },
+      "required": ["span_ops"]
+    },
+    "NumOfSpans": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string"
+        }
+      },
+      "required": ["unit", "value"]
+    },
+    "Contexts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "runtime": {
+          "$ref": "#/definitions/Runtime"
+        },
+        "trace": {
+          "$ref": "#/definitions/Trace"
+        }
+      },
+      "required": ["runtime", "trace"]
+    },
+    "Runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "build": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": ["build", "name", "type", "version"]
+    },
+    "Trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "trace_id": {
+          "type": "string"
+        },
+        "span_id": {
+          "type": "string"
+        },
+        "parent_span_id": {
+          "type": "string"
+        },
+        "op": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "exclusive_time": {
+          "type": "number"
+        },
+        "type": {
+          "type": "string"
+        },
+        "hash": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "exclusive_time",
+        "hash",
+        "op",
+        "parent_span_id",
+        "span_id",
+        "status",
+        "trace_id",
+        "type"
+      ]
+    },
+    "Extra": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "celery-job": {
+          "$ref": "#/definitions/CeleryJob"
+        },
+        "sys.argv": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["celery-job", "sys.argv"]
+    },
+    "CeleryJob": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "args": {
+          "type": "array",
+          "items": {}
+        },
+        "kwargs": {
+          "$ref": "#/definitions/OccurrenceData"
+        },
+        "task_name": {
+          "type": "string"
+        }
+      },
+      "required": ["args", "kwargs", "task_name"]
+    },
+    "OccurrenceData": {
+      "type": "object",
+      "additionalProperties": false
+    },
+    "GroupingConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enhancements": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": ["enhancements", "id"]
+    },
+    "Measurements": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "num_of_spans": {
+          "$ref": "#/definitions/NumOfSpans"
+        }
+      },
+      "required": ["num_of_spans"]
+    },
+    "Metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        }
+      },
+      "required": ["location", "title"]
+    },
+    "SDK": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "integrations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "packages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Package"
+          }
+        }
+      },
+      "required": ["integrations", "name", "packages", "version"]
+    },
+    "Package": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": ["name", "version"]
+    },
+    "SpanGroupingConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": ["id"]
+    },
+    "Span": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "timestamp": {
+          "type": "number"
+        },
+        "start_timestamp": {
+          "type": "number"
+        },
+        "exclusive_time": {
+          "type": "number"
+        },
+        "description": {
+          "type": "string"
+        },
+        "op": {
+          "type": "string"
+        },
+        "span_id": {
+          "type": "string"
+        },
+        "parent_span_id": {
+          "type": "string"
+        },
+        "trace_id": {
+          "type": "string"
+        },
+        "same_process_as_parent": {
+          "type": "boolean"
+        },
+        "tags": {
+          "type": "null"
+        },
+        "data": {
+          "type": "null"
+        },
+        "hash": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "description",
+        "exclusive_time",
+        "hash",
+        "op",
+        "parent_span_id",
+        "same_process_as_parent",
+        "span_id",
+        "start_timestamp",
+        "tags",
+        "timestamp",
+        "trace_id"
+      ]
+    },
+    "TransactionInfo": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "type": "string"
+        }
+      },
+      "required": ["source"]
     }
-  ]
+  }
 }

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -47,7 +47,7 @@
           "type": "null"
         },
         "retention_days": {
-          "type": "null"
+          "type": ["integer", "null"]
         },
         "occurrence_id": {
           "type": "null"
@@ -74,7 +74,27 @@
           "type": "null"
         }
       },
-      "required": []
+      "required": [
+        "group_id",
+        "group_ids",
+        "event_id",
+        "organization_id",
+        "project_id",
+        "message",
+        "platform",
+        "datetime",
+        "data",
+        "primary_hash",
+        "retention_days",
+        "occurrence_id",
+        "occurrence_data",
+        "is_new",
+        "is_regression",
+        "is_new_group_environment",
+        "queue",
+        "skip_consume",
+        "group_states"
+      ]
     },
     "Data": {
       "type": "object",

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -185,7 +185,9 @@
         },
         "hashes": {
           "type": "array",
-          "items": {}
+          "items": {
+            "type": "string"
+          }
         },
         "nodestore_insert": {
           "type": "number"

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -19,7 +19,9 @@
         },
         "group_ids": {
           "type": "array",
-          "maxItems": 0
+          "items": {
+            "type": "integer"
+          }
         },
         "event_id": {
           "type": "string"

--- a/topics/transactions.yaml
+++ b/topics/transactions.yaml
@@ -1,0 +1,9 @@
+topic: events
+description: Transactions data for Snuba
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: json
+    resource: transactions.v1.schema.json
+    examples:
+      - transactions/1/

--- a/topics/transactions.yaml
+++ b/topics/transactions.yaml
@@ -1,4 +1,4 @@
-topic: events
+topic: transactions
 description: Transactions data for Snuba
 schemas:
   - version: 1


### PR DESCRIPTION
I autogenerated this from the example and it's almost certainly wrong - just a starting point we will iterate on.

Kind of wished there was an easy way to share references between topics since transactions has a fair bit of overlap with events.