### PR TITLE
fix: Fix metric value types across all schemas

### DIFF
--- a/schemas/ingest-metrics.v1.schema.json
+++ b/schemas/ingest-metrics.v1.schema.json
@@ -43,16 +43,23 @@
         "value": {
           "anyOf": [
             {
-              "title": "number_metric_value",
+              "title": "counter_metric_value",
               "type": "number"
             },
             {
-              "title": "numbers_metric_value",
+              "title": "set_metric_value",
               "type": "array",
               "items": {
                 "type": "integer",
                 "minimum": 0,
                 "maximum": 4294967295
+              }
+            },
+            {
+              "title": "distribution_metric_value",
+              "type": "array",
+              "items": {
+                "type": "number"
               }
             }
           ]

--- a/schemas/ingest-metrics.v1.schema.json
+++ b/schemas/ingest-metrics.v1.schema.json
@@ -50,7 +50,9 @@
               "title": "numbers_metric_value",
               "type": "array",
               "items": {
-                "type": "number"
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 4294967295
               }
             }
           ]

--- a/schemas/snuba-generic-metrics.v1.schema.json
+++ b/schemas/snuba-generic-metrics.v1.schema.json
@@ -37,7 +37,7 @@
             {
               "type": "array",
               "items": {
-                "type": "integer"
+                "type": "number"
               }
             }
           ]

--- a/schemas/snuba-generic-metrics.v1.schema.json
+++ b/schemas/snuba-generic-metrics.v1.schema.json
@@ -32,12 +32,12 @@
         "value": {
           "anyOf": [
             {
-              "type": "integer"
+              "type": "number"
             },
             {
               "type": "array",
               "items": {
-                "type": "number"
+                "type": "integer"
               }
             }
           ]

--- a/schemas/snuba-metrics.v1.schema.json
+++ b/schemas/snuba-metrics.v1.schema.json
@@ -37,7 +37,7 @@
             {
               "type": "array",
               "items": {
-                "type": "integer"
+                "type": "number"
               }
             }
           ]

--- a/schemas/snuba-metrics.v1.schema.json
+++ b/schemas/snuba-metrics.v1.schema.json
@@ -32,12 +32,12 @@
         "value": {
           "anyOf": [
             {
-              "type": "integer"
+              "type": "number"
             },
             {
               "type": "array",
               "items": {
-                "type": "number"
+                "type": "integer"
               }
             }
           ]


### PR DESCRIPTION
The array of numbers can only ever be an array of u32s as per Relay
sourcecode. It is used for sets