### PR TITLE
fix: Standardise retention_days on events and transactions

### DIFF
--- a/schemas/events.v1.schema.json
+++ b/schemas/events.v1.schema.json
@@ -385,7 +385,7 @@
         "project_id": {
           "type": "integer"
         },
-        "retention_days": { "type": "integer" }
+        "retention_days": { "type": ["integer", "null"] }
       },
       "required": [
         "data",

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -49,7 +49,7 @@
           "type": "null"
         },
         "retention_days": {
-          "type": "null"
+          "type": ["integer", "null"]
         },
         "occurrence_id": {
           "type": "null"


### PR DESCRIPTION
Can be integer or null everywhere