### PR TITLE
feat: Remove unused fields from subscription results

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,3 @@
-# Search and storage is the default owner
-* @getsentry/owners-snuba
-
 # Ingest topics
 /topics/ingest-metrics.yaml                                @getsentry/owners-ingest @getsentry/owners-snuba
 
@@ -22,3 +19,6 @@
 /topics/generic-metrics-subscription-results.yaml         @getsentry/owners-snuba @getsentry/workflow
 /schemas/subscription-result.v1.schema.json               @getsentry/owners-snuba @getsentry/workflow
 /examples/subscription-results/                           @getsentry/owners-snuba @getsentry/workflow
+
+# Search and storage is the default owner
+* @getsentry/owners-snuba

--- a/examples/subscription-results/1/subscription-results-legacy.json
+++ b/examples/subscription-results/1/subscription-results-legacy.json
@@ -1,0 +1,35 @@
+{
+  "version": 3,
+  "payload": {
+    "subscription_id": "0/73fb573ac29811ed8dbb0242ac120006",
+    "result": {
+      "data": [
+        {
+          "count": 0
+        }
+      ],
+      "meta": [
+        {
+          "name": "count",
+          "type": "UInt64"
+        }
+      ],
+      "profile": {
+        "bytes": 64,
+        "blocks": 1,
+        "rows": 1,
+        "elapsed": 0.11267709732055664
+      },
+      "trace_output": ""
+    },
+    "request": {
+      "query": "MATCH (events) SELECT count() AS `count` WHERE type = \\'error\\' AND project_id IN array(4551586472787969)",
+      "tenant_ids": {
+        "organization_id": "<subscriptions>",
+        "referrer": "subscriptions_executor"
+      }
+    },
+    "entity": "metrics_counters",
+    "timestamp": "2020-01-01T01:23:45.1234"
+  }
+}

--- a/examples/subscription-results/1/subscription-results.json
+++ b/examples/subscription-results/1/subscription-results.json
@@ -13,14 +13,7 @@
           "name": "count",
           "type": "UInt64"
         }
-      ],
-      "profile": {
-        "bytes": 64,
-        "blocks": 1,
-        "rows": 1,
-        "elapsed": 0.11267709732055664
-      },
-      "trace_output": ""
+      ]
     },
     "request": {
       "query": "MATCH (events) SELECT count() AS `count` WHERE type = \\'error\\' AND project_id IN array(4551586472787969)",

--- a/schemas/subscription-results.v1.schema.json
+++ b/schemas/subscription-results.v1.schema.json
@@ -45,12 +45,6 @@
                     },
                     "additionalProperties": false
                   }
-                },
-                "profile": {
-                  "type": ["object", "null"]
-                },
-                "trace_output": {
-                  "type": "string"
                 }
               },
               "required": ["data", "meta"],


### PR DESCRIPTION
Whilst creating this schema and integrating it into Snuba and Sentry we discovered there were some fields ("profile" and "trace_output") being published that were essentially internal Snuba data and are completely unused by Sentry in the results consumer. Let's remove them from the schema and example.

Since "additionalProperties" is true, this is a backward compatible change and old messages still in the pipeline will not fail validation.