### PR TITLE
feat: Add Rust build cache to reduce CI times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Checkout code
+      - uses: actions/cache@v3
+        name: Restore build cache
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Run linter
         run: |
           make lint-rust


### PR DESCRIPTION
This job is currently by far the slowest one. We can reduce CI times by
quite a lot by caching Rust downloads and build artifacts

Copied from https://github.com/actions/cache/blob/main/examples.md#rust---cargo
