### PR TITLE
fix: Align snuba-metric value field with ingest-metrics

### DIFF
--- a/schemas/snuba-generic-metrics.v1.schema.json
+++ b/schemas/snuba-generic-metrics.v1.schema.json
@@ -32,9 +32,18 @@
         "value": {
           "anyOf": [
             {
+              "title": "counter_metric_value",
               "type": "number"
             },
             {
+              "title": "set_metric_value",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            {
+              "title": "distribution_metric_value",
               "type": "array",
               "items": {
                 "type": "number"

--- a/schemas/snuba-metrics.v1.schema.json
+++ b/schemas/snuba-metrics.v1.schema.json
@@ -32,9 +32,18 @@
         "value": {
           "anyOf": [
             {
+              "title": "counter_metric_value",
               "type": "number"
             },
             {
+              "title": "set_metric_value",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            {
+              "title": "distribution_metric_value",
               "type": "array",
               "items": {
                 "type": "number"


### PR DESCRIPTION
We are getting type-checking errors in https://github.com/getsentry/sentry/pull/46782, because

```
src/sentry/sentry_metrics/consumers/indexer/batch.py:383: error: Incompatible types (expression has type "Union[float, List[int], List[Union[int, float]]]", TypedDict item "value" has type "Union[int, float, List[int]]")  [typeddict-item]
```

This is because `List[int]` can't be cast to `Lint[Union[float, int]]`.

We should just reuse the definition sometime, but for now let's
copypaste.
