### PR TITLE
fix: Impl std::error::Error for SchemaError

### DIFF
--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use std::error;
+use std::fmt;
 use std::fs::{read_to_string, File};
 use std::path::{Path, PathBuf};
 
@@ -45,7 +45,7 @@ impl fmt::Display for SchemaError {
     }
 }
 
-impl error::Error for SchemaError { }
+impl error::Error for SchemaError {}
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct TopicSchema {

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::error;
 use std::fs::{read_to_string, File};
 use std::path::{Path, PathBuf};
 
@@ -43,6 +44,8 @@ impl fmt::Display for SchemaError {
         }
     }
 }
+
+impl error::Error for SchemaError { }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct TopicSchema {


### PR DESCRIPTION
This is just a rudimentary impl to satisfy some traits relay requires
