### PR TITLE
fix: Make generated schema types an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,6 @@ typify = { version = "0.0.11", optional = true }
 [build-dependencies]
 prettyplease = { version = "0.2.4", optional = true }
 schemars = { version = "0.8.0", optional = true }
-serde_json = { version = "1.0", optional = true }
+serde_json = "1.0"
 syn = { version = "2.0.11", optional = true }
 typify = { version = "0.0.11", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,11 @@ path = "rust/lib.rs"
 # https://stackoverflow.com/a/53728256/1544347
 name = "generate-schema-types"
 path = "rust/build.rs"
-required-features = ["build_deps"]
+required-features = ["type_generation"]
 
 [features]
-build_deps = ["prettyplease", "schemars", "syn", "typify"]
+default = ["type_generation"]
+type_generation = ["prettyplease", "schemars", "syn", "typify"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"]}
@@ -39,8 +40,8 @@ syn = { version = "2.0.11", optional = true }
 typify = { version = "0.0.11", optional = true }
 
 [build-dependencies]
-prettyplease = "0.2.4"
-schemars = "0.8.0"
-serde_json = "1.0"
-syn = "2.0.11"
-typify = "0.0.11"
+prettyplease = { version = "0.2.4", optional = true }
+schemars = { version = "0.8.0", optional = true }
+serde_json = { version = "1.0", optional = true }
+syn = { version = "2.0.11", optional = true }
+typify = { version = "0.0.11", optional = true }

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,10 +1,9 @@
 use std::path::Path;
 
-
 #[cfg(feature = "type_generation")]
 use {
     schemars::schema::Schema,
-    typify::{TypeSpace, TypeSpaceSettings}
+    typify::{TypeSpace, TypeSpaceSettings},
 };
 
 #[cfg(feature = "type_generation")]

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,8 +1,13 @@
 use std::path::Path;
 
-use schemars::schema::Schema;
-use typify::{TypeSpace, TypeSpaceSettings};
 
+#[cfg(feature = "type_generation")]
+use {
+    schemars::schema::Schema,
+    typify::{TypeSpace, TypeSpaceSettings}
+};
+
+#[cfg(feature = "type_generation")]
 fn generate_schema(schema_path: &str, output_module: &str) -> String {
     println!("cargo:rerun-if-changed={schema_path}");
     let json = std::fs::read_to_string(schema_path).expect("Read schema JSON file");
@@ -38,11 +43,16 @@ fn generate_schema(schema_path: &str, output_module: &str) -> String {
 }
 
 fn main() {
+    #[allow(unused_mut)]
     let mut module_code = String::new();
-    module_code.push_str(&generate_schema(
-        "schemas/ingest-metrics.v1.schema.json",
-        "ingest_metrics_v1",
-    ));
+
+    #[cfg(feature = "type_generation")]
+    {
+        module_code.push_str(&generate_schema(
+            "schemas/ingest-metrics.v1.schema.json",
+            "ingest_metrics_v1",
+        ));
+    }
 
     if let Ok(target_dir) = std::env::var("OUT_DIR") {
         println!("cargo:rerun-if-changed=build.rs");


### PR DESCRIPTION
Relay currently does not use those generated types, and there were
concerns about bloated dependency tree.
