### PR TITLE
fix(events): Fix the schema for tombstone events

### DIFF
--- a/examples/events/1/tombstone-events-no-datetime.json
+++ b/examples/events/1/tombstone-events-no-datetime.json
@@ -1,0 +1,11 @@
+[
+  2,
+  "tombstone_events",
+  {
+    "project_id": 123,
+    "event_ids": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
+    "old_primary_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "from_timestamp": "2023-04-06T00:00:00.000000Z",
+    "to_timestamp": "2023-04-06T00:00:00.000000Z"
+  }
+]

--- a/schemas/events.v1.schema.json
+++ b/schemas/events.v1.schema.json
@@ -249,7 +249,7 @@
             "datetime": { "$ref": "#/definitions/SnubaDatetime" }
           },
           "additionalProperties": false,
-          "required": ["project_id", "event_ids", "datetime"]
+          "required": ["project_id", "event_ids"]
         }
       ]
     },


### PR DESCRIPTION
I'm actually a bit confused by some of the other example tombstone events already checked in here because it doesn't look like Sentry is ever sending this

https://github.com/getsentry/sentry/blob/34a6dde71ea2f43c39ebc370e94692ca5e50555b/src/sentry/eventstream/snuba.py#L345-L351