### PR TITLE
fix(rust): Make regress dependency optional as well

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ required-features = ["type_generation"]
 
 [features]
 default = ["type_generation"]
-type_generation = ["prettyplease", "schemars", "syn", "typify"]
+type_generation = ["prettyplease", "schemars", "syn", "typify", "regress"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 serde_yaml = "0.9"
-regress = "0.5.0"  # required by generated code
+regress = { version = "0.5.0", features = ["type_generation"] }  # required by generated code
 
 # redeclare all build-dependencies here so that the build.rs can be used
 # standalone to view types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ type_generation = ["prettyplease", "schemars", "syn", "typify", "regress"]
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 serde_yaml = "0.9"
-regress = { version = "0.5.0", features = ["type_generation"] }  # required by generated code
+regress = { version = "0.5.0", optional = true }  # required by generated code
 
 # redeclare all build-dependencies here so that the build.rs can be used
 # standalone to view types


### PR DESCRIPTION
The dependency is only imported from within generated code.
