### PR TITLE
feat(metrics): Add sentry_received_timestamp to schemas to support indexer SLO

### DIFF
--- a/examples/snuba-generic-metrics/1/snuba-generic-metrics1.json
+++ b/examples/snuba-generic-metrics/1/snuba-generic-metrics1.json
@@ -16,6 +16,7 @@
     "5": "init"
   },
   "timestamp": 1677512412,
+  "origin_timestamp": 1677519000,
   "type": "c",
   "use_case_id": "performance",
   "value": 1

--- a/examples/snuba-generic-metrics/1/snuba-generic-metrics1.json
+++ b/examples/snuba-generic-metrics/1/snuba-generic-metrics1.json
@@ -16,7 +16,7 @@
     "5": "init"
   },
   "timestamp": 1677512412,
-  "origin_timestamp": 1677519000,
+  "sentry_received_timestamp": 1677519000.456,
   "type": "c",
   "use_case_id": "performance",
   "value": 1

--- a/examples/snuba-metrics/1/snuba-metrics1.json
+++ b/examples/snuba-metrics/1/snuba-metrics1.json
@@ -5,6 +5,7 @@
   "metric_id": 1232341,
   "type": "s",
   "timestamp": 1676388965,
+  "origin_timestamp": 1676390000,
   "tags": {
     "10": 11,
     "20": 22,

--- a/examples/snuba-metrics/1/snuba-metrics1.json
+++ b/examples/snuba-metrics/1/snuba-metrics1.json
@@ -5,7 +5,6 @@
   "metric_id": 1232341,
   "type": "s",
   "timestamp": 1676388965,
-  "sentry_received_timestamp": 1676390000.288,
   "tags": {
     "10": 11,
     "20": 22,

--- a/examples/snuba-metrics/1/snuba-metrics1.json
+++ b/examples/snuba-metrics/1/snuba-metrics1.json
@@ -5,7 +5,7 @@
   "metric_id": 1232341,
   "type": "s",
   "timestamp": 1676388965,
-  "origin_timestamp": 1676390000,
+  "sentry_received_timestamp": 1676390000.288,
   "tags": {
     "10": 11,
     "20": 22,

--- a/schemas/snuba-generic-metrics.v1.schema.json
+++ b/schemas/snuba-generic-metrics.v1.schema.json
@@ -26,8 +26,8 @@
         "timestamp": {
           "type": "integer"
         },
-        "origin_timestamp": {
-          "type": "integer"
+        "sentry_received_timestamp": {
+          "type": "number"
         },
         "tags": {
           "$ref": "#/definitions/StringToString"

--- a/schemas/snuba-generic-metrics.v1.schema.json
+++ b/schemas/snuba-generic-metrics.v1.schema.json
@@ -69,7 +69,6 @@
         "retention_days",
         "tags",
         "timestamp",
-        "sentry_received_timestamp",
         "type",
         "use_case_id",
         "value"

--- a/schemas/snuba-generic-metrics.v1.schema.json
+++ b/schemas/snuba-generic-metrics.v1.schema.json
@@ -26,6 +26,9 @@
         "timestamp": {
           "type": "integer"
         },
+        "origin_timestamp": {
+          "type": "integer"
+        },
         "tags": {
           "$ref": "#/definitions/StringToString"
         },
@@ -66,6 +69,7 @@
         "retention_days",
         "tags",
         "timestamp",
+        "origin_timestamp",
         "type",
         "use_case_id",
         "value"

--- a/schemas/snuba-generic-metrics.v1.schema.json
+++ b/schemas/snuba-generic-metrics.v1.schema.json
@@ -69,7 +69,7 @@
         "retention_days",
         "tags",
         "timestamp",
-        "origin_timestamp",
+        "sentry_received_timestamp",
         "type",
         "use_case_id",
         "value"

--- a/schemas/snuba-metrics.v1.schema.json
+++ b/schemas/snuba-metrics.v1.schema.json
@@ -69,7 +69,6 @@
         "retention_days",
         "tags",
         "timestamp",
-        "sentry_received_timestamp",
         "type",
         "use_case_id",
         "value"

--- a/schemas/snuba-metrics.v1.schema.json
+++ b/schemas/snuba-metrics.v1.schema.json
@@ -26,6 +26,9 @@
         "timestamp": {
           "type": "integer"
         },
+        "origin_timestamp": {
+          "type": "integer"
+        },
         "tags": {
           "$ref": "#/definitions/IntToInt"
         },
@@ -66,6 +69,7 @@
         "retention_days",
         "tags",
         "timestamp",
+        "origin_timestamp",
         "type",
         "use_case_id",
         "value"

--- a/schemas/snuba-metrics.v1.schema.json
+++ b/schemas/snuba-metrics.v1.schema.json
@@ -26,8 +26,8 @@
         "timestamp": {
           "type": "integer"
         },
-        "origin_timestamp": {
-          "type": "integer"
+        "sentry_received_timestamp": {
+          "type": "number"
         },
         "tags": {
           "$ref": "#/definitions/IntToInt"

--- a/schemas/snuba-metrics.v1.schema.json
+++ b/schemas/snuba-metrics.v1.schema.json
@@ -69,7 +69,7 @@
         "retention_days",
         "tags",
         "timestamp",
-        "origin_timestamp",
+        "sentry_received_timestamp",
         "type",
         "use_case_id",
         "value"


### PR DESCRIPTION
Supporting the work started here: https://github.com/getsentry/sentry/pull/47577. 

If we change the name of the field in the above PR, will make corresponding changes here as well.