### PR TITLE
ref: Move to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,32 @@
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "sentry-kafka-schemas"
+dependencies = [
+    "python-rapidjson==1.8",
+    "PyYAML>=5.4,<7.0",
+    "typing-extensions>=4.0.0"
+]
+version = "0.0.29"
+authors = [
+    {"name" = "Sentry", email = "oss@sentry.io"}
+]
+
+description = "Kafka topics and schemas for Sentry"
+readme = "README.md"
+license = { file = "LICENSE" }
+
+[tool.setuptools]
+include-package-data = true
+zip-safe = false
+
+[tool.setuptools.package-data]
+sentry_kafka_schemas = ["py.typed"]
+
+[tool.setuptools.packages.find]
+where = ["python/"]
+
+[tool.distutils.bdist_wheel]
+universal = true

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,0 @@
-python-rapidjson==1.8
-PyYAML>=5.4,<7.0
-typing-extensions>=4.0.0

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,3 @@
-from setuptools import find_packages, setup
+from setuptools import setup
 
-from typing import Sequence
-
-
-def get_requirements() -> Sequence[str]:
-    with open("python/requirements.txt") as fp:
-        return [x.strip() for x in fp if not x.startswith("#")]
-
-setup(
-    name="sentry-kafka-schemas",
-    version="0.0.29",
-    author="Sentry",
-    author_email="oss@sentry.io",
-    url="https://github.com/getsentry/sentry-kafka-schemas",
-    description="Kafka topics and schemas for Sentry",
-    zip_safe=False,
-    install_requires=get_requirements(),
-    packages=["sentry_kafka_schemas", "sentry_kafka_schemas.schema_types"],
-    package_dir={"": "python/"},
-    package_data={"sentry_kafka_schemas": ["py.typed"]},
-    include_package_data=True,
-    options={"bdist_wheel": {"universal": "1"}},
-)
+setup()


### PR DESCRIPTION
WIP of moving to pyproject.toml so I can use https://github.com/mitsuhiko/rye

Whether that's a good idea is TBD -- semi-sure it will break craft
