### PR TITLE
fix: Loosen metrics schemas

### DIFF
--- a/schemas/snuba-generic-metrics.v1.schema.json
+++ b/schemas/snuba-generic-metrics.v1.schema.json
@@ -5,7 +5,7 @@
     "Main": {
       "type": "object",
       "title": "generic_metric",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "version": { "const": 2 },
         "use_case_id": {

--- a/schemas/snuba-metrics.v1.schema.json
+++ b/schemas/snuba-metrics.v1.schema.json
@@ -5,7 +5,7 @@
     "Main": {
       "title": "metric",
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "version": { "const": 1 },
         "use_case_id": {


### PR DESCRIPTION
We decided to be less strict across the board and allow `additionalProperties=true` everywhere so messages won't fail schema validation if they are unlikely to crash consumers. This updates the metrics and generic metrics schemas to allow additional properties.