### PR TITLE
feat(geo): Add subdivision to event schema

### DIFF
--- a/schemas/events.v1.schema.json
+++ b/schemas/events.v1.schema.json
@@ -1415,6 +1415,10 @@
             "region": {
               "description": " Human readable region name or code.",
               "type": ["string", "null"]
+            },
+            "subdivision": {
+              "description": " Human readable subdivision name.",
+              "type": ["string", "null"]
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
With subdivision is stored (https://github.com/getsentry/relay/pull/2058), this PR is updating the event schema to include it in the `geo` data.