### PR TITLE
fix(doc): Document how to use a schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,25 @@ The yaml file of a topic has 2 keys:
    - `resource`: Should match the file name in the `schemas` directory
    - `examples`: Should match the file names in the `examples` directory
 
-## Using Python types
+## Using the schema (in Python)
+
+```python
+from sentry_kafka_schemas import get_codec, ValidationError
+from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
+
+SCHEMA: Codec[IngestMetric] = get_codec("ingest-metrics")
+
+try:
+    decoded = SCHEMA.decode(b'{"type": "c", ...}')
+except ValidationError:
+    return
+
+# ingest-metrics schema defines retention_days as required type, so this is
+# safe.
+retention_days = decoded["retention_days"]
+```
+
+### Using Python types
 
 Python types are automatically generated under
 `sentry_kafka_schemas.schema_types`. A schema for version 1 of the topic

--- a/python/sentry_kafka_schemas/codecs/__init__.py
+++ b/python/sentry_kafka_schemas/codecs/__init__.py
@@ -6,7 +6,7 @@ T = TypeVar("T")
 
 class Codec(ABC, Generic[T]):
     @abstractmethod
-    def encode(self, data: T, validate: bool) -> bytes:
+    def encode(self, data: T, validate: bool = True) -> bytes:
         """
         Decode bytes from Kafka message.
         If validate is true, validation is performed.
@@ -14,7 +14,7 @@ class Codec(ABC, Generic[T]):
         raise NotImplementedError
 
     @abstractmethod
-    def decode(self, raw_data: bytes, validate: bool) -> T:
+    def decode(self, raw_data: bytes, validate: bool = True) -> T:
         """
         Decode bytes from Kafka message.
         If validate is true, validation is performed.

--- a/python/sentry_kafka_schemas/codecs/json.py
+++ b/python/sentry_kafka_schemas/codecs/json.py
@@ -17,12 +17,12 @@ class JsonCodec(Codec[T]):
     ) -> None:
         self.__validate = fastjsonschema.compile(json_schema)
 
-    def encode(self, data: T, validate: bool) -> bytes:
+    def encode(self, data: T, validate: bool = True) -> bytes:
         if validate:
             self.validate(data)
         return cast(bytes, rapidjson.dumps(data).encode("utf-8"))
 
-    def decode(self, raw_data: bytes, validate: bool) -> Any:
+    def decode(self, raw_data: bytes, validate: bool = True) -> Any:
         decoded = rapidjson.loads(raw_data)
         if validate:
             self.validate(decoded)

--- a/python/sentry_kafka_schemas/codecs/msgpack.py
+++ b/python/sentry_kafka_schemas/codecs/msgpack.py
@@ -16,12 +16,12 @@ class MsgpackCodec(Codec[T]):
     def __init__(self, json_schema: object) -> None:
         self.__validate = fastjsonschema.compile(json_schema)
 
-    def encode(self, data: T, validate: bool) -> bytes:
+    def encode(self, data: T, validate: bool = True) -> bytes:
         if validate:
             self.validate(data)
         return cast(bytes, msgpack.packb(data))
 
-    def decode(self, raw_data: bytes, validate: bool) -> T:
+    def decode(self, raw_data: bytes, validate: bool = True) -> T:
         decoded = msgpack.unpackb(raw_data)
         if validate:
             self.validate(decoded)


### PR DESCRIPTION
I noticed we didn't have any docs on how to actually use schemas. Add a
simple example that uses both Python types and codecs at once.

Also make the validate parameter default to true in codecs.
