### PR TITLE
fix(build): Add missing module to setup.py

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,4 +27,4 @@ jobs:
       # validate that the built wheel is actually importable
       - run: python -m venv /tmp/venv
       - run: /tmp/venv/bin/pip install dist/*.whl
-      - run: /tmp/venv/bin/python -m sentry_kafka_schemas
+      - run: /tmp/venv/bin/python -c 'import sentry_kafka_schemas'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,3 +21,8 @@ jobs:
         with:
           name: ${{ github.sha }}
           path: dist/*
+
+      # validate that the built wheel is actually importable
+      - run: python -m venv /tmp/venv
+      - run: /tmp/venv/bin/pip install dist/*.whl
+      - run: /tmp/venv/bin/python -m sentry_kafka_schemas

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - release/**
+  pull_request:
 
 jobs:
   dist:
@@ -18,6 +19,7 @@ jobs:
           python-version: 3.8
       - run: make build
       - uses: actions/upload-artifact@v2
+        if: github.event_name != 'pull_request'
         with:
           name: ${{ github.sha }}
           path: dist/*

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description="Kafka topics and schemas for Sentry",
     zip_safe=False,
     install_requires=get_requirements(),
-    packages=["sentry_kafka_schemas", "sentry_kafka_schemas.schema_types"],
+    packages=find_packages(where="python/", exclude=["generate_python_types.py", "tests/"]),
     package_dir={"": "python/"},
     package_data={"sentry_kafka_schemas": ["py.typed"]},
     include_package_data=True,


### PR DESCRIPTION
https://github.com/getsentry/pypi/pull/289 was never merged because the produced wheel is junk, because the `codecs` module was not declared in setup.py. Fix that and add CI to prevent that from happening again.