### PR TITLE
feat: JsonCodec and MsgpackCodec are usable without schemas

### DIFF
--- a/python/sentry_kafka_schemas/codecs/json.py
+++ b/python/sentry_kafka_schemas/codecs/json.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, TypeVar, cast
+from typing import Any, Optional, TypeVar, cast
 
 import fastjsonschema
 import rapidjson
@@ -13,9 +13,12 @@ T = TypeVar("T")
 class JsonCodec(Codec[T]):
     def __init__(
         self,
-        json_schema: object,
+        json_schema: Optional[object],
     ) -> None:
-        self.__validate = fastjsonschema.compile(json_schema)
+        if json_schema is not None:
+            self.__validate = fastjsonschema.compile(json_schema)
+        else:
+            self.__validate = lambda _: None
 
     def encode(self, data: T, validate: bool) -> bytes:
         if validate:

--- a/python/sentry_kafka_schemas/codecs/msgpack.py
+++ b/python/sentry_kafka_schemas/codecs/msgpack.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, cast
+from typing import Optional, TypeVar, cast
 
 import fastjsonschema
 import msgpack
@@ -13,8 +13,11 @@ class MsgpackCodec(Codec[T]):
     This codec assumes the payload is json.
     """
 
-    def __init__(self, json_schema: object) -> None:
-        self.__validate = fastjsonschema.compile(json_schema)
+    def __init__(self, json_schema: Optional[object]) -> None:
+        if json_schema is not None:
+            self.__validate = fastjsonschema.compile(json_schema)
+        else:
+            self.__validate = lambda _: None
 
     def encode(self, data: T, validate: bool) -> bytes:
         if validate:


### PR DESCRIPTION
Schema is optional in the JsonCodec and MsgpackCodec. So they can be used for topics where a schema isn't defined yet. Otherwise a separate codec will need to be defined for all topics which don't have a schema, which is a pain for users.

This is the same as the Arroyo implementation does.