### PR TITLE
fix: Make Codec.validate public

### DIFF
--- a/python/sentry_kafka_schemas/codecs/__init__.py
+++ b/python/sentry_kafka_schemas/codecs/__init__.py
@@ -30,7 +30,7 @@ class Codec(ABC, Generic[T]):
         Calling `decode(validate=False)` and then `validate()` should be
         equivalent to `decode(validate=True)`.
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class ValidationError(Exception):

--- a/python/sentry_kafka_schemas/codecs/__init__.py
+++ b/python/sentry_kafka_schemas/codecs/__init__.py
@@ -21,6 +21,16 @@ class Codec(ABC, Generic[T]):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def validate(self, data: T) -> None:
+        """
+
+        Validate a decoded Python object again.
+
+        Calling `decode(validate=False)` and then `validate()` should be
+        equivalent to `decode(validate=True)`.
+        """
+
 
 class ValidationError(Exception):
     """

--- a/python/sentry_kafka_schemas/codecs/__init__.py
+++ b/python/sentry_kafka_schemas/codecs/__init__.py
@@ -30,6 +30,7 @@ class Codec(ABC, Generic[T]):
         Calling `decode(validate=False)` and then `validate()` should be
         equivalent to `decode(validate=True)`.
         """
+        raise NotImplementedError()
 
 
 class ValidationError(Exception):


### PR DESCRIPTION
I didn't realize the entire time that that method was not on the
baseclass. It is useful because currently we are treating validation
errors as just warnings, meaning that we need to decode even if
validation fails.

We already effectively used arroyo codecs this way.
