### PR TITLE
fix: Improve formatting of schema diff further

### DIFF
--- a/.github/workflows/schema-changes.yml
+++ b/.github/workflows/schema-changes.yml
@@ -46,7 +46,7 @@ jobs:
             --features build-binary
       - name: Generate schema diff
         if: github.event_name == 'pull_request'
-        uses: getsentry/action-migrations@v1.2.1
+        uses: getsentry/action-migrations@v1.2.2
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           useRawBody: "true"

--- a/schemas/events.v1.schema.json
+++ b/schemas/events.v1.schema.json
@@ -460,7 +460,7 @@
         "extra": {
           "description": " Arbitrary extra information set by the user.\n\n ```json\n {\n     \"extra\": {\n         \"my_key\": 1,\n         \"some_other_value\": \"foo bar\"\n     }\n }```",
           "type": ["object", "null"],
-          "additionalProperties": true
+          "additionalProperties": false
         },
         "fingerprint": {
           "description": " Manual fingerprint override.\n\n A list of strings used to dictate how this event is supposed to be grouped with other\n events into issues. For more information about overriding grouping see [Customize Grouping\n with Fingerprints](https://docs.sentry.io/data-management/event-grouping/).\n\n ```json\n {\n     \"fingerprint\": [\"myrpc\", \"POST\", \"/foo.bar\"]\n }",

--- a/schemas/events.v1.schema.json
+++ b/schemas/events.v1.schema.json
@@ -460,7 +460,7 @@
         "extra": {
           "description": " Arbitrary extra information set by the user.\n\n ```json\n {\n     \"extra\": {\n         \"my_key\": 1,\n         \"some_other_value\": \"foo bar\"\n     }\n }```",
           "type": ["object", "null"],
-          "additionalProperties": false
+          "additionalProperties": true
         },
         "fingerprint": {
           "description": " Manual fingerprint override.\n\n A list of strings used to dictate how this event is supposed to be grouped with other\n events into issues. For more information about overriding grouping see [Customize Grouping\n with Fingerprints](https://docs.sentry.io/data-management/event-grouping/).\n\n ```json\n {\n     \"fingerprint\": [\"myrpc\", \"POST\", \"/foo.bar\"]\n }",

--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -71,10 +71,9 @@ def main() -> None:
                 else:
                     non_breaking_changes.setdefault(filename, []).append(change)
 
-    # bogus line to get rid of indentation added by actions-migrations
-    print("<!-- -->")
 
     if breaking_changes:
+        print("&nbsp;")
         print("<details><summary><h4>changes considered breaking</h4></summary>")
         print_files_and_changes(breaking_changes)
         print("</details>")

--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -71,6 +71,9 @@ def main() -> None:
                 else:
                     non_breaking_changes.setdefault(filename, []).append(change)
 
+    # bogus line to get rid of indentation added by actions-migrations
+    print("<!-- -->")
+
     if breaking_changes:
         print("<details><summary><h4>changes considered breaking</h4></summary>")
         print_files_and_changes(breaking_changes)

--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -42,13 +42,13 @@ def main() -> None:
     )
     lines = process_output.decode("utf8").splitlines()
 
+    if not lines:
+        return
+
     breaking_changes: MutableMapping[str, MutableSequence[Change]] = {}
     non_breaking_changes: MutableMapping[str, MutableSequence[Change]] = {}
     consumers: MutableSequence[str] = []
     producers: MutableSequence[str] = []
-
-    if not lines:
-        return
 
     for filename in lines:
         consumers.extend(_SCHEMA_FILE_TO_TOPIC[filename]["services"]["consumers"])
@@ -129,12 +129,10 @@ Take a look at the README for how to release a new version of sentry-kafka-schem
 
 def print_files_and_changes(file_to_changes: Mapping[str, Sequence[Change]]) -> None:
     print()
-    print("```")
     for filename, changes in file_to_changes.items():
         print(f"### {filename}")
         for change in changes:
             print_change(change)
-    print("```")
     print()
 
 
@@ -168,10 +166,15 @@ def print_change(change: Change) -> None:
     change.pop("is_breaking")
 
     printer = _CHANGE_PRINTERS.get(next(iter(change["change"])))
+    print("- ", end='')
     if printer:
-        print(f"## {printer(change)}")
+        print(f"**{printer(change)}**")
+        print()
+        print("  ", end='')
 
-    print(json.dumps(change))
+    print(f"```")
+    print(f"  {json.dumps(change)}")
+    print(f"  ```")
     print()
 
 

--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -166,11 +166,11 @@ def print_change(change: Change) -> None:
     change.pop("is_breaking")
 
     printer = _CHANGE_PRINTERS.get(next(iter(change["change"])))
-    print("- ", end='')
+    print("- ", end="")
     if printer:
         print(f"**{printer(change)}**")
         print()
-        print("  ", end='')
+        print("  ", end="")
 
     print(f"```")
     print(f"  {json.dumps(change)}")

--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -71,11 +71,10 @@ def main() -> None:
                 else:
                     non_breaking_changes.setdefault(filename, []).append(change)
 
-    print()
-
     if breaking_changes:
-        print("#### changes considered breaking:")
+        print("<details><summary><h4>changes considered breaking</h4></summary>")
         print_files_and_changes(breaking_changes)
+        print("</details>")
 
     if non_breaking_changes:
         print("<details><summary><strong>benign changes</strong></summary>")

--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -177,9 +177,9 @@ def print_change(change: Change) -> None:
         print()
         print("  ", end="")
 
-    print(f"```")
+    print("```")
     print(f"  {json.dumps(change)}")
-    print(f"  ```")
+    print("  ```")
     print()
 
 

--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -72,8 +72,11 @@ def main() -> None:
                     non_breaking_changes.setdefault(filename, []).append(change)
 
 
+    if breaking_changes or non_breaking_changes:
+        # bogus value to get rid of indentation added by action-migrations
+        print(".")
+
     if breaking_changes:
-        print("&nbsp;")
         print("<details><summary><strong>changes considered breaking</strong></summary>")
         print_files_and_changes(breaking_changes)
         print("</details>")

--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -71,8 +71,10 @@ def main() -> None:
                 else:
                     non_breaking_changes.setdefault(filename, []).append(change)
 
+    print()
+
     if breaking_changes:
-        print("**changes considered breaking:**")
+        print("#### changes considered breaking:")
         print_files_and_changes(breaking_changes)
 
     if non_breaking_changes:
@@ -130,7 +132,7 @@ Take a look at the README for how to release a new version of sentry-kafka-schem
 def print_files_and_changes(file_to_changes: Mapping[str, Sequence[Change]]) -> None:
     print()
     for filename, changes in file_to_changes.items():
-        print(f"### {filename}")
+        print(f"**{filename}**")
         for change in changes:
             print_change(change)
     print()
@@ -147,18 +149,18 @@ def _add_change_printer(f: ChangePrinter) -> ChangePrinter:
 
 @_add_change_printer
 def TypeRemove(change: Change) -> str:
-    return f"Restricted the type of {change['path']}, as {change['change']['TypeRemove']['removed']} is no longer allowed"
+    return f"Restricted the type of `{change['path']}`, as `{change['change']['TypeRemove']['removed']}` is no longer allowed"
 
 
 @_add_change_printer
 def PropertyRemove(change: Change) -> str:
-    first_sentence = f"Removed a property {change['change']['PropertyRemove']['removed']} from {change['path']}"
+    first_sentence = f"Removed a property `{change['change']['PropertyRemove']['removed']}` from `{change['path']}`"
     if change["change"]["PropertyRemove"]["lhs_additional_properties"]:
         return (
-            f"{first_sentence}, but it is still accepted via additionalProperties=true"
+            f"{first_sentence}, but it is still accepted via `additionalProperties=true`"
         )
     else:
-        return f"{first_sentence}, so it is no longer accepted. Maybe use additionalProperties?"
+        return f"{first_sentence}, so it is no longer accepted. Maybe use `additionalProperties`?"
 
 
 def print_change(change: Change) -> None:
@@ -168,7 +170,7 @@ def print_change(change: Change) -> None:
     printer = _CHANGE_PRINTERS.get(next(iter(change["change"])))
     print("- ", end="")
     if printer:
-        print(f"**{printer(change)}**")
+        print(f"{printer(change)}")
         print()
         print("  ", end="")
 

--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -71,13 +71,14 @@ def main() -> None:
                 else:
                     non_breaking_changes.setdefault(filename, []).append(change)
 
-
     if breaking_changes or non_breaking_changes:
         # bogus value to get rid of indentation added by action-migrations
         print(".")
 
     if breaking_changes:
-        print("<details><summary><strong>changes considered breaking</strong></summary>")
+        print(
+            "<details><summary><strong>changes considered breaking</strong></summary>"
+        )
         print_files_and_changes(breaking_changes)
         print("</details>")
 

--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -156,9 +156,7 @@ def TypeRemove(change: Change) -> str:
 def PropertyRemove(change: Change) -> str:
     first_sentence = f"Removed a property `{change['change']['PropertyRemove']['removed']}` from `{change['path']}`"
     if change["change"]["PropertyRemove"]["lhs_additional_properties"]:
-        return (
-            f"{first_sentence}, but it is still accepted via `additionalProperties=true`"
-        )
+        return f"{first_sentence}, but it is still accepted via `additionalProperties=true`"
     else:
         return f"{first_sentence}, so it is no longer accepted. Maybe use `additionalProperties`?"
 

--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -71,10 +71,6 @@ def main() -> None:
                 else:
                     non_breaking_changes.setdefault(filename, []).append(change)
 
-    if breaking_changes or non_breaking_changes:
-        # bogus value to get rid of indentation added by action-migrations
-        print(".")
-
     if breaking_changes:
         print(
             "<details><summary><strong>changes considered breaking</strong></summary>"

--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -74,7 +74,7 @@ def main() -> None:
 
     if breaking_changes:
         print("&nbsp;")
-        print("<details><summary><h4>changes considered breaking</h4></summary>")
+        print("<details><summary><strong>changes considered breaking</strong></summary>")
         print_files_and_changes(breaking_changes)
         print("</details>")
 


### PR DESCRIPTION
Printing a codeblock is kind of ugly -- let's try markdown lists
