### PR TITLE
fix: Adjust breaking changes warning

### DIFF
--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -120,10 +120,13 @@ https://github.com/getsentry/json-schema-diff/ and figure it out?"""
             """
 ⚠️ **This PR contains breaking changes.** Normally you should avoid that and make
 your consumer forwards-compatible (meaning that updated consumers can still
-accept old messages).
+accept old messages). There are a few exceptions:
 
-If you know what you are doing, this change could potentially be rolled out
-to **producers** first, but that's not a flow we support.
+* If consumers already require these invariants in practice, and you're
+  just adjusting the JSON schema to reality, ignore this warning.
+
+* If you know what you are doing, this change could potentially be rolled out
+  to **producers** first, but that's not a flow we support.
 """
         )
         if "--no-exit-code" not in sys.argv:


### PR DESCRIPTION
https://github.com/getsentry/sentry-kafka-schemas/pull/132 shows that
there is a legitimate usecase for breaking changes in the schema: When
the schema is just plain wrong and the consumer would already crash on
those now-invalid messages today.
