### PR TITLE
fix(transactions): Fix parent-span-id

### DIFF
--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -938,7 +938,7 @@
           "type": "string"
         },
         "parent_span_id": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "trace_id": {
           "type": "string"
@@ -962,7 +962,6 @@
         "exclusive_time",
         "hash",
         "op",
-        "parent_span_id",
         "same_process_as_parent",
         "span_id",
         "start_timestamp",


### PR DESCRIPTION
As per https://github.com/getsentry/snuba/blob/68172ab32529364c912efd4da26b85d85ac47389/snuba/datasets/processors/spans_processor.py#L402, parent_span_id can be null, and it is also not required.