### PR TITLE
fix(transactions): Remove properties incorrectly set to required in trace context

### DIFF
--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -958,12 +958,7 @@
       },
       "required": [
         "data",
-        "description",
-        "exclusive_time",
-        "hash",
-        "op",
         "parent_span_id",
-        "same_process_as_parent",
         "span_id",
         "start_timestamp",
         "tags",

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -726,7 +726,7 @@
           "type": "string"
         }
       },
-      "required": ["unit", "value"]
+      "required": ["value"]
     },
     "ProfileContext": {
       "description": " Profile context",


### PR DESCRIPTION
Neither the Snuba transactions or spans consumers require these fields.

Needed for https://github.com/getsentry/sentry/pull/48670