### PR TITLE
fix(transactions): measurement.unit is not required

### DIFF
--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -726,7 +726,7 @@
           "type": "string"
         }
       },
-      "required": ["unit", "value"]
+      "required": ["value"]
     },
     "ProfileContext": {
       "description": " Profile context",


### PR DESCRIPTION
Snuba spans processor only uses the value and ignores the unit https://github.com/getsentry/snuba/blob/68172ab32529364c912efd4da26b85d85ac47389/snuba/datasets/processors/spans_processor.py#L215-L244

Also needed for https://github.com/getsentry/sentry/pull/48670