### PR TITLE
feat: Add generic-events topic

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,7 @@
 /topics/outcomes.yaml                                      @getsentry/owners-snuba
 /topics/snuba-metrics.yaml                                 @getsentry/owners-snuba
 /topics/snuba-generic-metrics.yaml                         @getsentry/owners-snuba
+/topics/generic-events.yaml                                @getsentry/owners-snuba @getsentry/issues
 
 # Internal Snuba topics
 /topics/snuba-queries.yaml                                 @getsentry/owners-snuba

--- a/examples/generic-events/1/insert.json
+++ b/examples/generic-events/1/insert.json
@@ -1,42 +1,42 @@
 [
-    2,
-    "insert",
-    {
-      "data": {
-        "environment": "production",
-        "event_id": "9cdc4c32dff14fbbb012b0aa9e908126",
-        "level": "error",
-        "logger": "",
-        "platform": "javascript",
-        "received": 1677512412.437706,
-        "release": "123abc",
-        "timestamp": 1677512412.223,
-        "type": "error",
-        "version": "7"
-      },
-      "datetime": "2023-02-27T15:40:12.223000Z",
+  2,
+  "insert",
+  {
+    "data": {
+      "environment": "production",
       "event_id": "9cdc4c32dff14fbbb012b0aa9e908126",
-      "group_id": 124,
-      "group_ids": [124],
-      "message": "hello world",
-      "organization_id": 123,
+      "level": "error",
+      "logger": "",
       "platform": "javascript",
-      "primary_hash": "061cf02b26374d108694d6643a7a2f4e",
-      "project_id": 6036610
+      "received": 1677512412.437706,
+      "release": "123abc",
+      "timestamp": 1677512412.223,
+      "type": "error",
+      "version": "7"
     },
-    {
-      "group_states": [
-        {
-          "id": "124",
-          "is_new": false,
-          "is_new_group_environment": false,
-          "is_regression": false
-        }
-      ],
-      "is_new": false,
-      "is_new_group_environment": false,
-      "is_regression": false,
-      "queue": "post_process_errors",
-      "skip_consume": false
-    }
-  ]
+    "datetime": "2023-02-27T15:40:12.223000Z",
+    "event_id": "9cdc4c32dff14fbbb012b0aa9e908126",
+    "group_id": 124,
+    "group_ids": [124],
+    "message": "hello world",
+    "organization_id": 123,
+    "platform": "javascript",
+    "primary_hash": "061cf02b26374d108694d6643a7a2f4e",
+    "project_id": 6036610
+  },
+  {
+    "group_states": [
+      {
+        "id": "124",
+        "is_new": false,
+        "is_new_group_environment": false,
+        "is_regression": false
+      }
+    ],
+    "is_new": false,
+    "is_new_group_environment": false,
+    "is_regression": false,
+    "queue": "post_process_errors",
+    "skip_consume": false
+  }
+]

--- a/examples/generic-events/1/insert.json
+++ b/examples/generic-events/1/insert.json
@@ -1,0 +1,42 @@
+[
+    2,
+    "insert",
+    {
+      "data": {
+        "environment": "production",
+        "event_id": "9cdc4c32dff14fbbb012b0aa9e908126",
+        "level": "error",
+        "logger": "",
+        "platform": "javascript",
+        "received": 1677512412.437706,
+        "release": "123abc",
+        "timestamp": 1677512412.223,
+        "type": "error",
+        "version": "7"
+      },
+      "datetime": "2023-02-27T15:40:12.223000Z",
+      "event_id": "9cdc4c32dff14fbbb012b0aa9e908126",
+      "group_id": 124,
+      "group_ids": [124],
+      "message": "hello world",
+      "organization_id": 123,
+      "platform": "javascript",
+      "primary_hash": "061cf02b26374d108694d6643a7a2f4e",
+      "project_id": 6036610
+    },
+    {
+      "group_states": [
+        {
+          "id": "124",
+          "is_new": false,
+          "is_new_group_environment": false,
+          "is_regression": false
+        }
+      ],
+      "is_new": false,
+      "is_new_group_environment": false,
+      "is_regression": false,
+      "queue": "post_process_errors",
+      "skip_consume": false
+    }
+  ]

--- a/topics/generic-events.yaml
+++ b/topics/generic-events.yaml
@@ -1,0 +1,15 @@
+topic: generic-events
+pipeline: generic_events
+description: Issue platform
+services:
+  producers:
+    - getsentry/sentry
+  consumers:
+    - getsentry/snuba
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: json
+    resource: events.v1.schema.json
+    examples:
+      - generic-events/1/


### PR DESCRIPTION
Currently this points at the same schema as "events". Though technically there are only inserts on this topic and not replacements.