### PR TITLE
feat(generic-events): Fix schema and example

### DIFF
--- a/examples/generic-events/1/insert.json
+++ b/examples/generic-events/1/insert.json
@@ -22,7 +22,21 @@
     "organization_id": 123,
     "platform": "javascript",
     "primary_hash": "061cf02b26374d108694d6643a7a2f4e",
-    "project_id": 6036610
+    "project_id": 1,
+    "occurrence_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "occurrence_data": {
+      "id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "project_id": 1,
+      "event_id": "cccccccccccccccccccccccccccccccc",
+      "fingerprint": ["dddddddddddddddddddddddddddddddd"],
+      "issue_title": "N+1 Query",
+      "subtitle": "select one, two, three from foo",
+      "resource_id": null,
+      "type": 1006,
+      "detection_time": 1677512412.11,
+      "level": "info",
+      "culprit": "/some/api/user/{user}/"
+    }
   },
   {
     "group_states": [

--- a/schemas/generic-events.v1.schema.json
+++ b/schemas/generic-events.v1.schema.json
@@ -1,0 +1,1915 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "generic_event",
+  "description": "Issue platform event",
+  "anyOf": [{ "$ref": "#/definitions/InsertEventMessage" }],
+  "definitions": {
+    "SnubaDatetime": {
+      "type": "string"
+    },
+    "InsertEventMessage": {
+      "type": "array",
+      "items": [
+        { "const": 2 },
+        { "const": "insert" },
+        {
+          "$ref": "#/definitions/InsertEvent"
+        },
+        {
+          "$ref": "#/definitions/GroupInformation"
+        }
+      ]
+    },
+    "GroupInformation": {
+      "type": "object",
+      "properties": {
+        "group_states": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GroupState"
+          }
+        },
+        "is_new": {
+          "type": "boolean"
+        },
+        "is_new_group_environment": {
+          "type": "boolean"
+        },
+        "is_regression": {
+          "type": "boolean"
+        },
+        "queue": {
+          "type": "string"
+        },
+        "skip_consume": {
+          "type": "boolean"
+        }
+      }
+    },
+    "GroupState": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$comment": "yes, we have seen both types in prod, not sure where they come from",
+          "type": ["string", "integer"]
+        },
+        "is_new": {
+          "type": "boolean"
+        },
+        "is_new_group_environment": {
+          "type": "boolean"
+        },
+        "is_regression": {
+          "type": "boolean"
+        }
+      }
+    },
+    "InsertEvent": {
+      "type": "object",
+      "title": "insert_event",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/Event"
+        },
+        "datetime": {
+          "type": "string"
+        },
+        "event_id": {
+          "$ref": "#/definitions/EventId"
+        },
+        "group_id": {
+          "type": "integer"
+        },
+        "group_ids": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "message": {
+          "type": "string"
+        },
+        "organization_id": {
+          "type": "integer"
+        },
+        "platform": {
+          "type": "string"
+        },
+        "primary_hash": {
+          "type": "string"
+        },
+        "project_id": {
+          "type": "integer"
+        },
+        "retention_days": { "type": ["integer", "null"] },
+        "occurrence_id": {
+          "type": "string"
+        },
+        "occurrence_data": {
+          "type": "object",
+          "properties": {
+            "detection_time": { "type": "number" },
+            "fingerprint": { "type": "array", "items": { "type": "string" } },
+            "issue_title": { "type": "string" },
+            "subtitle": { "type": ["string", "null"] },
+            "culprit": { "type": ["string", "null"] },
+            "level": { "type": ["string", "null"] },
+            "resource_id": { "type": ["string", "null"] },
+            "id": { "type": "string" },
+            "type": { "type": "integer" }
+          },
+          "required": [
+            "detection_time",
+            "fingerprint",
+            "issue_title",
+            "id",
+            "type"
+          ]
+        }
+      },
+      "required": [
+        "data",
+        "project_id",
+        "datetime",
+        "event_id",
+        "message",
+        "primary_hash",
+        "platform",
+        "group_id",
+        "occurrence_id",
+        "occurrence_data"
+      ]
+    },
+    "Event": {
+      "description": "The sentry v7 event structure.",
+      "type": "object",
+      "title": "sentry_event",
+      "additionalProperties": true,
+      "required": ["received"],
+      "properties": {
+        "type": { "type": "string" },
+        "contexts": {
+          "description": " Contexts describing the environment (e.g. device, os or browser).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Contexts"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "culprit": {
+          "description": " Custom culprit of the event.\n\n This field is deprecated and shall not be set by client SDKs.",
+          "type": ["string", "null"]
+        },
+        "dist": {
+          "description": " Program's distribution identifier.\n\n The distribution of the application.\n\n Distributions are used to disambiguate build or deployment variants of the same release of\n an application. For example, the dist can be the build number of an XCode build or the\n version code of an Android build.",
+          "type": ["string", "null"]
+        },
+        "environment": {
+          "description": " The environment name, such as `production` or `staging`.\n\n ```json\n { \"environment\": \"production\" }\n ```",
+          "type": ["string", "null"]
+        },
+        "errors": {
+          "description": " Errors encountered during processing. Intended to be phased out in favor of\n annotation/metadata system.",
+          "default": null,
+          "type": ["array", "null"],
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/EventProcessingError"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "event_id": {
+          "description": " Unique identifier of this event.\n\n Hexadecimal string representing a uuid4 value. The length is exactly 32 characters. Dashes\n are not allowed. Has to be lowercase.\n\n Even though this field is backfilled on the server with a new uuid4, it is strongly\n recommended to generate that uuid4 clientside. There are some features like user feedback\n which are easier to implement that way, and debugging in case events get lost in your\n Sentry installation is also easier.\n\n Example:\n\n ```json\n {\n   \"event_id\": \"fc6d8c0c43fc4630ad850ee518f1b9d0\"\n }\n ```",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/EventId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "exception": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ExceptionChain"
+            },
+            { "type": "null" }
+          ]
+        },
+        "threads": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadChain"
+            },
+            { "type": "null" }
+          ]
+        },
+        "extra": {
+          "description": " Arbitrary extra information set by the user.\n\n ```json\n {\n     \"extra\": {\n         \"my_key\": 1,\n         \"some_other_value\": \"foo bar\"\n     }\n }```",
+          "type": ["object", "null"],
+          "additionalProperties": true
+        },
+        "fingerprint": {
+          "description": " Manual fingerprint override.\n\n A list of strings used to dictate how this event is supposed to be grouped with other\n events into issues. For more information about overriding grouping see [Customize Grouping\n with Fingerprints](https://docs.sentry.io/data-management/event-grouping/).\n\n ```json\n {\n     \"fingerprint\": [\"myrpc\", \"POST\", \"/foo.bar\"]\n }",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Fingerprint"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "description": " Severity level of the event. Defaults to `error`.\n\n Example:\n\n ```json\n {\"level\": \"warning\"}\n ```",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Level"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "logentry": {
+          "description": " Custom parameterized message for this event.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LogEntry"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "logger": {
+          "description": " Logger that created the event.",
+          "type": ["string", "null"]
+        },
+        "modules": {
+          "description": " Name and versions of all installed modules/packages/dependencies in the current\n environment/application.\n\n ```json\n { \"django\": \"3.0.0\", \"celery\": \"4.2.1\" }\n ```\n\n In Python this is a list of installed packages as reported by `pkg_resources` together with\n their reported version string.\n\n This is primarily used for suggesting to enable certain SDK integrations from within the UI\n and for making informed decisions on which frameworks to support in future development\n efforts.",
+          "type": ["object", "null"],
+          "additionalProperties": {
+            "type": ["string", "null"]
+          }
+        },
+        "platform": {
+          "description": " Platform identifier of this event (defaults to \"other\").\n\n A string representing the platform the SDK is submitting from. This will be used by the\n Sentry interface to customize various components in the interface, but also to enter or\n skip stacktrace processing.\n\n Acceptable values are: `as3`, `c`, `cfml`, `cocoa`, `csharp`, `elixir`, `haskell`, `go`,\n `groovy`, `java`, `javascript`, `native`, `node`, `objc`, `other`, `perl`, `php`, `python`,\n `ruby`",
+          "type": ["string", "null"]
+        },
+        "received": {
+          "description": " Timestamp when the event has been received by Sentry.",
+          "$ref": "#/definitions/Timestamp"
+        },
+        "release": {
+          "description": " The release version of the application.\n\n **Release versions must be unique across all projects in your organization.** This value\n can be the git SHA for the given project, or a product identifier with a semantic version.",
+          "type": ["string", "null"]
+        },
+        "request": {
+          "description": " Information about a web request that occurred during the event.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Request"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sdk": {
+          "description": " Information about the Sentry SDK that generated this event.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ClientSdkInfo"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "server_name": {
+          "description": " Server or device name the event was generated on.\n\n This is supposed to be a hostname.",
+          "type": ["string", "null"]
+        },
+        "stacktrace": {
+          "description": " Event stacktrace.\n\n DEPRECATED: Prefer `threads` or `exception` depending on which is more appropriate.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Stacktrace"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tags": {
+          "description": " Custom tags for this event.\n\n A map or list of tags for this event. Each tag must be less than 200 characters.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Tags"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "time_spent": {
+          "description": " Time since the start of the transaction until the error occurred.",
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "timestamp": {
+          "description": " Timestamp when the event was created.\n\n Indicates when the event was created in the Sentry SDK. The format is either a string as\n defined in [RFC 3339](https://tools.ietf.org/html/rfc3339) or a numeric (integer or float)\n value representing the number of seconds that have elapsed since the [Unix\n epoch](https://en.wikipedia.org/wiki/Unix_time).\n\n Timezone is assumed to be UTC if missing.\n\n Sub-microsecond precision is not preserved with numeric values due to precision\n limitations with floats (at least in our systems). With that caveat in mind, just send\n whatever is easiest to produce.\n\n All timestamps in the event protocol are formatted this way.\n\n # Example\n\n All of these are the same date:\n\n ```json\n { \"timestamp\": \"2011-05-02T17:41:36Z\" }\n { \"timestamp\": \"2011-05-02T17:41:36\" }\n { \"timestamp\": \"2011-05-02T17:41:36.000\" }\n { \"timestamp\": 1304358096.0 }\n ```",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Timestamp"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "transaction": {
+          "description": " Transaction name of the event.\n\n For example, in a web app, this might be the route name (`\"/users/<username>/\"` or\n `UserView`), in a task queue it might be the function + module name.",
+          "type": ["string", "null"]
+        },
+        "transaction_info": {
+          "description": " Additional information about the name of the transaction.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TransactionInfo"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "description": " Type of the event. Defaults to `default`.\n\n The event type determines how Sentry handles the event and has an impact on processing, rate\n limiting, and quotas. There are three fundamental classes of event types:\n\n  - **Error monitoring events**: Processed and grouped into unique issues based on their\n    exception stack traces and error messages.\n  - **Security events**: Derived from Browser security violation reports and grouped into\n    unique issues based on the endpoint and violation. SDKs do not send such events.\n  - **Transaction events** (`transaction`): Contain operation spans and collected into traces\n    for performance monitoring.\n\n Transactions must explicitly specify the `\"transaction\"` event type. In all other cases,\n Sentry infers the appropriate event type from the payload and overrides the stated type.\n SDKs should not send an event type other than for transactions.\n\n Example:\n\n ```json\n {\n   \"type\": \"transaction\",\n   \"spans\": []\n }\n ```",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/EventType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "user": {
+          "description": " Information about the user who triggered this event.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/User"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "version": {
+          "description": " Version",
+          "type": ["string", "null"]
+        },
+        "hierarchical_hashes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Addr": {
+      "type": "string"
+    },
+    "AppContext": {
+      "description": " Application information.\n\n App context describes the application. As opposed to the runtime, this is the actual\n application that was running and carries metadata about the current session.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "app_build": {
+              "description": " Internal build ID as it appears on the platform.",
+              "type": ["string", "null"]
+            },
+            "app_identifier": {
+              "description": " Version-independent application identifier, often a dotted bundle ID.",
+              "type": ["string", "null"]
+            },
+            "app_memory": {
+              "description": " Amount of memory used by the application in bytes.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "app_name": {
+              "description": " Application name as it appears on the platform.",
+              "type": ["string", "null"]
+            },
+            "app_start_time": {
+              "description": " Start time of the app.\n\n Formatted UTC timestamp when the user started the application.",
+              "type": ["string", "null"]
+            },
+            "app_version": {
+              "description": " Application version as it appears on the platform.",
+              "type": ["string", "null"]
+            },
+            "build_type": {
+              "description": " String identifying the kind of build. For example, `testflight`.",
+              "type": ["string", "null"]
+            },
+            "device_app_hash": {
+              "description": " Application-specific device identifier.",
+              "type": ["string", "null"]
+            },
+            "in_foreground": {
+              "description": " A flag indicating whether the app is in foreground or not. An app is in foreground when it's visible to the user.",
+              "type": ["boolean", "null"]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "BrowserContext": {
+      "description": " Web browser information.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": " Display name of the browser application.",
+              "type": ["string", "null"]
+            },
+            "version": {
+              "description": " Version string of the browser.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "ClientSdkInfo": {
+      "title": "client_sdk_info",
+      "description": " The SDK Interface describes the Sentry SDK and its configuration used to capture and transmit an event.",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": ["name", "version"],
+          "properties": {
+            "integrations": {
+              "description": " List of integrations that are enabled in the SDK. _Optional._\n\n The list should have all enabled integrations, including default integrations. Default\n integrations are included because different SDK releases may contain different default\n integrations.",
+              "type": ["array", "null"],
+              "items": {
+                "type": ["string", "null"]
+              }
+            },
+            "name": {
+              "description": " Unique SDK name. _Required._\n\n The name of the SDK. The format is `entity.ecosystem[.flavor]` where entity identifies the\n developer of the SDK, ecosystem refers to the programming language or platform where the\n SDK is to be used and the optional flavor is used to identify standalone SDKs that are part\n of a major ecosystem.\n\n Official Sentry SDKs use the entity `sentry`, as in `sentry.python` or\n `sentry.javascript.react-native`. Please use a different entity for your own SDKs.",
+              "type": ["string", "null"]
+            },
+            "version": {
+              "description": " The version of the SDK. _Required._\n\n It should have the [Semantic Versioning](https://semver.org/) format `MAJOR.MINOR.PATCH`,\n without any prefix (no `v` or anything else in front of the major version number).\n\n Examples: `0.1.0`, `1.0.0`, `4.3.12`",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "CloudResourceContext": {
+      "description": " Cloud Resource Context.\n\n This context describes the cloud resource the event originated from.\n\n Example:\n\n ```json\n \"cloud_resource\": {\n     \"cloud.account.id\": \"499517922981\",\n     \"cloud.provider\": \"aws\",\n     \"cloud.platform\": \"aws_ec2\",\n     \"cloud.region\": \"us-east-1\",\n     \"cloud.vavailability_zone\": \"us-east-1e\",\n     \"host.id\": \"i-07d3301208fe0a55a\",\n     \"host.type\": \"t2.large\"\n }\n ```",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cloud.account.id": {
+              "description": " The cloud account ID the resource is assigned to.",
+              "type": ["string", "null"]
+            },
+            "cloud.availability_zone": {
+              "description": " The zone where the resource is running.",
+              "type": ["string", "null"]
+            },
+            "cloud.platform": {
+              "description": " The cloud platform in use.\n The prefix of the service SHOULD match the one specified in cloud_provider.",
+              "type": ["string", "null"]
+            },
+            "cloud.provider": {
+              "description": " Name of the cloud provider.",
+              "type": ["string", "null"]
+            },
+            "cloud.region": {
+              "description": " The geographical region the resource is running.",
+              "type": ["string", "null"]
+            },
+            "host.id": {
+              "description": " Unique host ID.",
+              "type": ["string", "null"]
+            },
+            "host.type": {
+              "description": " Machine type of the host.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "CodeId": {
+      "type": "string"
+    },
+    "Context": {
+      "description": " A context describes environment info (e.g. device, os or browser).",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DeviceContext"
+        },
+        {
+          "$ref": "#/definitions/OsContext"
+        },
+        {
+          "$ref": "#/definitions/RuntimeContext"
+        },
+        {
+          "$ref": "#/definitions/AppContext"
+        },
+        {
+          "$ref": "#/definitions/BrowserContext"
+        },
+        {
+          "$ref": "#/definitions/GpuContext"
+        },
+        {
+          "$ref": "#/definitions/TraceContext"
+        },
+        {
+          "$ref": "#/definitions/ProfileContext"
+        },
+        {
+          "$ref": "#/definitions/MonitorContext"
+        },
+        {
+          "$ref": "#/definitions/ResponseContext"
+        },
+        {
+          "$ref": "#/definitions/OtelContext"
+        },
+        {
+          "$ref": "#/definitions/CloudResourceContext"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true
+        }
+      ]
+    },
+    "Contexts": {
+      "description": " The Contexts Interface provides additional context data. Typically, this is data related to the\n current user and the environment. For example, the device or application version. Its canonical\n name is `contexts`.\n\n The `contexts` type can be used to define arbitrary contextual data on the event. It accepts an\n object of key/value pairs. The key is the “alias” of the context and can be freely chosen.\n However, as per policy, it should match the type of the context unless there are two values for\n a type. You can omit `type` if the key name is the type.\n\n Unknown data for the contexts is rendered as a key/value list.\n\n For more details about sending additional data with your event, see the [full documentation on\n Additional Data](https://docs.sentry.io/enriching-error-data/additional-data/).",
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Context"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "Cookies": {
+      "description": " A map holding cookies.",
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": ["string", "null"]
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": ["array", "null"],
+                "items": [
+                  {
+                    "type": ["string", "null"]
+                  },
+                  {
+                    "type": ["string", "null"]
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "DeviceContext": {
+      "description": " Device information.\n\n Device context describes the device that caused the event. This is most appropriate for mobile\n applications.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "arch": {
+              "description": " Native cpu architecture of the device.",
+              "type": ["string", "null"]
+            },
+            "battery_level": {
+              "description": " Current battery level in %.\n\n If the device has a battery, this can be a floating point value defining the battery level\n (in the range 0-100).",
+              "type": ["number", "null"]
+            },
+            "battery_status": {
+              "description": " Status of the device's battery.\n\n For example, `Unknown`, `Charging`, `Discharging`, `NotCharging`, `Full`.",
+              "type": ["string", "null"]
+            },
+            "boot_time": {
+              "description": " Indicator when the device was booted.",
+              "type": ["string", "null"]
+            },
+            "brand": {
+              "description": " Brand of the device.",
+              "type": ["string", "null"]
+            },
+            "charging": {
+              "description": " Whether the device was charging or not.",
+              "type": ["boolean", "null"]
+            },
+            "cpu_description": {
+              "description": " CPU description.\n\n For example, Intel(R) Core(TM)2 Quad CPU Q6600 @ 2.40GHz.",
+              "type": ["string", "null"]
+            },
+            "device_type": {
+              "description": " Kind of device the application is running on.\n\n For example, `Unknown`, `Handheld`, `Console`, `Desktop`.",
+              "type": ["string", "null"]
+            },
+            "device_unique_identifier": {
+              "description": " Unique device identifier.",
+              "type": ["string", "null"]
+            },
+            "external_free_storage": {
+              "description": " Free size of the attached external storage in bytes (eg: android SDK card).",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "external_storage_size": {
+              "description": " Total size of the attached external storage in bytes (eg: android SDK card).",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "family": {
+              "description": " Family of the device model.\n\n This is usually the common part of model names across generations. For instance, `iPhone`\n would be a reasonable family, so would be `Samsung Galaxy`.",
+              "type": ["string", "null"]
+            },
+            "free_memory": {
+              "description": " How much memory is still available in bytes.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "free_storage": {
+              "description": " How much storage is free in bytes.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "low_memory": {
+              "description": " Whether the device was low on memory.",
+              "type": ["boolean", "null"]
+            },
+            "manufacturer": {
+              "description": " Manufacturer of the device.",
+              "type": ["string", "null"]
+            },
+            "memory_size": {
+              "description": " Total memory available in bytes.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "model": {
+              "description": " Device model.\n\n This, for example, can be `Samsung Galaxy S3`.",
+              "type": ["string", "null"]
+            },
+            "model_id": {
+              "description": " Device model (internal identifier).\n\n An internal hardware revision to identify the device exactly.",
+              "type": ["string", "null"]
+            },
+            "name": {
+              "description": " Name of the device.",
+              "type": ["string", "null"]
+            },
+            "online": {
+              "description": " Whether the device was online or not.",
+              "type": ["boolean", "null"]
+            },
+            "orientation": {
+              "description": " Current screen orientation.\n\n This can be a string `portrait` or `landscape` to define the orientation of a device.",
+              "type": ["string", "null"]
+            },
+            "processor_count": {
+              "description": " Number of \"logical processors\".\n\n For example, 8.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "processor_frequency": {
+              "description": " Processor frequency in MHz.\n\n Note that the actual CPU frequency might vary depending on current load and\n power conditions, especially on low-powered devices like phones and laptops.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "screen_density": {
+              "description": " Device screen density.",
+              "type": ["number", "null"]
+            },
+            "screen_dpi": {
+              "description": " Screen density as dots-per-inch.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "screen_resolution": {
+              "description": " Device screen resolution.\n\n (e.g.: 800x600, 3040x1444)",
+              "type": ["string", "null"]
+            },
+            "simulator": {
+              "description": " Simulator/prod indicator.",
+              "type": ["boolean", "null"]
+            },
+            "storage_size": {
+              "description": " Total storage size of the device in bytes.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "supports_accelerometer": {
+              "description": " Whether the accelerometer is available on the device.",
+              "type": ["boolean", "null"]
+            },
+            "supports_audio": {
+              "description": " Whether audio is available on the device.",
+              "type": ["boolean", "null"]
+            },
+            "supports_gyroscope": {
+              "description": " Whether the gyroscope is available on the device.",
+              "type": ["boolean", "null"]
+            },
+            "supports_location_service": {
+              "description": " Whether location support is available on the device.",
+              "type": ["boolean", "null"]
+            },
+            "supports_vibration": {
+              "description": " Whether vibration is available on the device.",
+              "type": ["boolean", "null"]
+            },
+            "timezone": {
+              "description": " Timezone of the device.",
+              "type": ["string", "null"]
+            },
+            "usable_memory": {
+              "description": " How much memory is usable for the app in bytes.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "EventId": {
+      "description": " Wrapper around a UUID with slightly different formatting.",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "EventProcessingError": {
+      "description": " An event processing error.",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "name": {
+              "description": " Affected key or deep path.",
+              "default": null,
+              "type": ["string", "null"]
+            },
+            "type": {
+              "description": " The error kind.",
+              "type": ["string", "null"]
+            },
+            "value": {
+              "description": " The original value causing this error.",
+              "default": null
+            }
+          }
+        }
+      ]
+    },
+    "EventType": {
+      "description": "The type of an event.\n\nThe event type determines how Sentry handles the event and has an impact on processing, rate limiting, and quotas. There are three fundamental classes of event types:\n\n- **Error monitoring events** (`default`, `error`): Processed and grouped into unique issues based on their exception stack traces and error messages. - **Security events** (`csp`, `hpkp`, `expectct`, `expectstaple`): Derived from Browser security violation reports and grouped into unique issues based on the endpoint and violation. SDKs do not send such events. - **Transaction events** (`transaction`): Contain operation spans and collected into traces for performance monitoring.",
+      "type": "string",
+      "enum": [
+        "error",
+        "csp",
+        "hpkp",
+        "expectct",
+        "expectstaple",
+        "transaction",
+        "default"
+      ]
+    },
+    "ExceptionChain": {
+      "title": "sentry_exception_chain",
+      "description": " One or multiple chained (nested) exceptions.",
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": ["null", "array"],
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Exception"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "ThreadChain": {
+      "title": "sentry_thread_chain",
+      "description": " One or multiple threads.",
+      "type": "object",
+      "required": ["values"],
+      "properties": {
+        "values": {
+          "type": ["null", "array"],
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Thread"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "Exception": {
+      "description": " A single exception.\n\n Multiple values inside of an [event](#typedef-Event) represent chained exceptions and should be sorted oldest to newest. For example, consider this Python code snippet:\n\n ```python\n try:\n     raise Exception(\"random boring invariant was not met!\")\n except Exception as e:\n     raise ValueError(\"something went wrong, help!\") from e\n ```\n\n `Exception` would be described first in the values list, followed by a description of `ValueError`:\n\n ```json\n {\n   \"exception\": {\n     \"values\": [\n       {\"type\": \"Exception\": \"value\": \"random boring invariant was not met!\"},\n       {\"type\": \"ValueError\", \"value\": \"something went wrong, help!\"},\n     ]\n   }\n }\n ```",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "mechanism": {
+              "description": " Mechanism by which this exception was generated and handled.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Mechanism"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "module": {
+              "description": " The optional module, or package which the exception type lives in.",
+              "type": ["string", "null"]
+            },
+            "stacktrace": {
+              "description": " Stack trace containing frames of this exception.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Stacktrace"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "raw_stacktrace": {
+              "description": " Stack trace containing frames of this exception.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Stacktrace"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "thread_id": {
+              "description": " An optional value that refers to a [thread](#typedef-Thread).",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ThreadId"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "description": " Exception type, e.g. `ValueError`.\n\n At least one of `type` or `value` is required, otherwise the exception is discarded.",
+              "type": ["string", "null"]
+            },
+            "value": {
+              "description": " Human readable display value.\n\n At least one of `type` or `value` is required, otherwise the exception is discarded.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/JsonLenientString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "Thread": {
+      "description": " A single thread.\n\n The Threads Interface specifies threads that were running at the time an event happened.\n These threads can also contain stack traces.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "id": {
+              "description": " An optional value that refers to a [thread](#typedef-Thread).",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ThreadId"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "main": {
+              "description": " If applicable, a flag indicating whether the thread was responsible for rendering the user interface.\n\n On mobile platforms this is oftentimes referred to as the `main thread` or `ui thread`.",
+              "type": ["boolean", "null"]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "Fingerprint": {
+      "description": " A fingerprint value.",
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "Frame": {
+      "description": " Holds information about a single stacktrace frame.\n\n Each object should contain **at least** a `filename`, `function` or `instruction_addr`\n attribute. All values are optional, but recommended.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "abs_path": {
+              "description": " Absolute path to the source file.",
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "addr_mode": {
+              "description": " Defines the addressing mode for addresses.\n\n This can be:\n - `\"abs\"` (the default): `instruction_addr` is absolute.\n - `\"rel:$idx\"`: `instruction_addr` is relative to the `debug_meta.image` identified by its index in the list.\n - `\"rel:$uuid\"`: `instruction_addr` is relative to the `debug_meta.image` identified by its `debug_id`.\n\n If one of the `\"rel:XXX\"` variants is given together with `function_id`, the `instruction_addr` is relative\n to the uniquely identified function in the references `debug_meta.image`.",
+              "type": ["string", "null"]
+            },
+            "colno": {
+              "description": " Column number within the source file, starting at 1.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "context_line": {
+              "description": " Source code of the current line (`lineno`).",
+              "type": ["string", "null"]
+            },
+            "filename": {
+              "description": " The source file name (basename only).",
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "function": {
+              "description": " Name of the frame's function. This might include the name of a class.\n\n This function name may be shortened or demangled. If not, Sentry will demangle and shorten\n it for some platforms. The original function name will be stored in `raw_function`.",
+              "type": ["string", "null"]
+            },
+            "function_id": {
+              "description": " (.NET) The function id / index that uniquely identifies a function inside a module.\n\n This is the `MetadataToken` of a .NET `MethodBase`.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "image_addr": {
+              "description": " (C/C++/Native) Start address of the containing code module (image).",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "in_app": {
+              "description": " Override whether this frame should be considered part of application code, or part of\n libraries/frameworks/dependencies.\n\n Setting this attribute to `false` causes the frame to be hidden/collapsed by default and\n mostly ignored during issue grouping.",
+              "type": ["boolean", "null"]
+            },
+            "instruction_addr": {
+              "description": " (C/C++/Native) An optional instruction address for symbolication.\n\n This should be a string with a hexadecimal number that includes a 0x prefix.\n If this is set and a known image is defined in the\n [Debug Meta Interface]({%- link _documentation/development/sdk-dev/event-payloads/debugmeta.md -%}),\n then symbolication can take place.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "lineno": {
+              "description": " Line number within the source file, starting at 1.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "module": {
+              "description": " Name of the module the frame is contained in.\n\n Note that this might also include a class name if that is something the\n language natively considers to be part of the stack (for instance in Java).",
+              "type": ["string", "null"]
+            },
+            "package": {
+              "description": " Name of the package that contains the frame.\n\n For instance this can be a dylib for native languages, the name of the jar\n or .NET assembly.",
+              "type": ["string", "null"]
+            },
+            "platform": {
+              "description": " Which platform this frame is from.\n\n This can override the platform for a single frame. Otherwise, the platform of the event is\n assumed. This can be used for multi-platform stack traces, such as in React Native.",
+              "type": ["string", "null"]
+            },
+            "post_context": {
+              "description": " Source code of the lines after `lineno`.",
+              "type": ["array", "null"],
+              "items": {
+                "type": ["string", "null"]
+              }
+            },
+            "pre_context": {
+              "description": " Source code leading up to `lineno`.",
+              "type": ["array", "null"],
+              "items": {
+                "type": ["string", "null"]
+              }
+            },
+            "raw_function": {
+              "description": " A raw (but potentially truncated) function value.\n\n The original function name, if the function name is shortened or demangled. Sentry shows the\n raw function when clicking on the shortened one in the UI.\n\n If this has the same value as `function` it's best to be omitted.  This exists because on\n many platforms the function itself contains additional information like overload specifies\n or a lot of generics which can make it exceed the maximum limit we provide for the field.\n In those cases then we cannot reliably trim down the function any more at a later point\n because the more valuable information has been removed.\n\n The logic to be applied is that an intelligently trimmed function name should be stored in\n `function` and the value before trimming is stored in this field instead.  However also this\n field will be capped at 256 characters at the moment which often means that not the entire\n original value can be stored.",
+              "type": ["string", "null"]
+            },
+            "stack_start": {
+              "description": " Marks this frame as the bottom of a chained stack trace.\n\n Stack traces from asynchronous code consist of several sub traces that are chained together\n into one large list. This flag indicates the root function of a chained stack trace.\n Depending on the runtime and thread, this is either the `main` function or a thread base\n stub.\n\n This field should only be specified when true.",
+              "type": ["boolean", "null"]
+            },
+            "symbol": {
+              "description": " Potentially mangled name of the symbol as it appears in an executable.\n\n This is different from a function name by generally being the mangled\n name that appears natively in the binary.  This is relevant for languages\n like Swift, C++ or Rust.",
+              "type": ["string", "null"]
+            },
+            "symbol_addr": {
+              "description": " (C/C++/Native) Start address of the frame's function.\n\n We use the instruction address for symbolication, but this can be used to calculate\n an instruction offset automatically.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "vars": {
+              "description": " Mapping of local variables and expression names that were available in this frame.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FrameVars"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "FrameVars": {
+      "description": " Frame local variables.",
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": true
+        }
+      ]
+    },
+    "Geo": {
+      "description": " Geographical location of the end user or device.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "city": {
+              "description": " Human readable city name.",
+              "type": ["string", "null"]
+            },
+            "country_code": {
+              "description": " Two-letter country code (ISO 3166-1 alpha-2).",
+              "type": ["string", "null"]
+            },
+            "region": {
+              "description": " Human readable region name or code.",
+              "type": ["string", "null"]
+            },
+            "subdivision": {
+              "description": " Human readable subdivision name.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "GpuContext": {
+      "description": " GPU information.\n\n Example:\n\n ```json\n \"gpu\": {\n   \"name\": \"AMD Radeon Pro 560\",\n   \"vendor_name\": \"Apple\",\n   \"memory_size\": 4096,\n   \"api_type\": \"Metal\",\n   \"multi_threaded_rendering\": true,\n   \"version\": \"Metal\",\n   \"npot_support\": \"Full\"\n }\n ```",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "api_type": {
+              "description": " The device low-level API type.\n\n Examples: `\"Apple Metal\"` or `\"Direct3D11\"`",
+              "type": ["string", "null"]
+            },
+            "graphics_shader_level": {
+              "description": " Approximate \"shader capability\" level of the graphics device.\n\n For Example: Shader Model 2.0, OpenGL ES 3.0, Metal / OpenGL ES 3.1, 27 (unknown)",
+              "type": ["string", "null"]
+            },
+            "id": {
+              "description": " The PCI identifier of the graphics device.",
+              "type": ["null", "string"]
+            },
+            "max_texture_size": {
+              "description": " Largest size of a texture that is supported by the graphics hardware.\n\n For Example: 16384",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "memory_size": {
+              "description": " The total GPU memory available in Megabytes.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "multi_threaded_rendering": {
+              "description": " Whether the GPU has multi-threaded rendering or not.",
+              "type": ["boolean", "null"]
+            },
+            "name": {
+              "description": " The name of the graphics device.",
+              "type": ["string", "null"]
+            },
+            "npot_support": {
+              "description": " The Non-Power-Of-Two support.",
+              "type": ["string", "null"]
+            },
+            "supports_compute_shaders": {
+              "description": " Whether compute shaders are available on the device.",
+              "type": ["boolean", "null"]
+            },
+            "supports_draw_call_instancing": {
+              "description": " Whether GPU draw call instancing is supported.",
+              "type": ["boolean", "null"]
+            },
+            "supports_geometry_shaders": {
+              "description": " Whether geometry shaders are available on the device.",
+              "type": ["boolean", "null"]
+            },
+            "supports_ray_tracing": {
+              "description": " Whether ray tracing is available on the device.",
+              "type": ["boolean", "null"]
+            },
+            "vendor_id": {
+              "description": " The PCI vendor identifier of the graphics device.",
+              "type": ["string", "null"]
+            },
+            "vendor_name": {
+              "description": " The vendor name as reported by the graphics device.",
+              "type": ["string", "null"]
+            },
+            "version": {
+              "description": " The Version of the graphics device.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "HeaderName": {
+      "description": " A \"into-string\" type that normalizes header names.",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "HeaderValue": {
+      "description": " A \"into-string\" type that normalizes header values.",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "Headers": {
+      "description": " A map holding headers.",
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/HeaderValue"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": ["array", "null"],
+                "items": [
+                  {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/HeaderName"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/HeaderValue"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "InstructionAddrAdjustment": {
+      "description": "Controls the mechanism by which the `instruction_addr` of a [`Stacktrace`] [`Frame`] is adjusted.\n\nThe adjustment tries to transform *return addresses* to *call addresses* for symbolication. Typically, this adjustment needs to be done for all frames but the first, as the first frame is usually taken directly from the cpu context of a hardware exception or a suspended thread and the stack trace is created from that.\n\nWhen the stack walking implementation truncates frames from the top, `\"all\"` frames should be adjusted. In case the stack walking implementation already does the adjustment when producing stack frames, `\"none\"` should be used here.",
+      "type": "string",
+      "enum": ["auto", "all_but_first", "all", "none"]
+    },
+    "JsonLenientString": {
+      "description": " A \"into-string\" type of value. All non-string values are serialized as JSON.",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "Level": {
+      "description": "Severity level of an event or breadcrumb.",
+      "type": "string",
+      "enum": ["debug", "info", "warning", "error", "fatal"]
+    },
+    "LogEntry": {
+      "description": " A log entry message.\n\n A log message is similar to the `message` attribute on the event itself but\n can additionally hold optional parameters.\n\n ```json\n {\n   \"message\": {\n     \"message\": \"My raw message with interpreted strings like %s\",\n     \"params\": [\"this\"]\n   }\n }\n ```\n\n ```json\n {\n   \"message\": {\n     \"message\": \"My raw message with interpreted strings like {foo}\",\n     \"params\": {\"foo\": \"this\"}\n   }\n }\n ```",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "formatted": {
+              "description": " The formatted message. If `message` and `params` are given, Sentry\n will attempt to backfill `formatted` if empty.\n\n It must not exceed 8192 characters. Longer messages will be truncated.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Message"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "message": {
+              "description": " The log message with parameter placeholders.\n\n This attribute is primarily used for grouping related events together into issues.\n Therefore this really should just be a string template, i.e. `Sending %d requests` instead\n of `Sending 9999 requests`. The latter is much better at home in `formatted`.\n\n It must not exceed 8192 characters. Longer messages will be truncated.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Message"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "params": {
+              "type": ["object", "array", "null"],
+              "description": " Parameters to be interpolated into the log message. This can be an array of positional\n parameters as well as a mapping of named arguments to their values."
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "Mechanism": {
+      "description": " The mechanism by which an exception was generated and handled.\n\n The exception mechanism is an optional field residing in the [exception](#typedef-Exception).\n It carries additional information about the way the exception was created on the target system.\n This includes general exception values obtained from the operating system or runtime APIs, as\n well as mechanism-specific values.",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "handled": {
+              "description": " Flag indicating whether this exception was handled.\n\n This is a best-effort guess at whether the exception was handled by user code or not. For\n example:\n\n - Exceptions leading to a 500 Internal Server Error or to a hard process crash are\n   `handled=false`, as the SDK typically has an integration that automatically captures the\n   error.\n\n - Exceptions captured using `capture_exception` (called from user code) are `handled=true`\n   as the user explicitly captured the exception (and therefore kind of handled it)",
+              "type": ["boolean", "null"]
+            },
+            "type": {
+              "description": " Mechanism type (required).\n\n Required unique identifier of this mechanism determining rendering and processing of the\n mechanism data.\n\n In the Python SDK this is merely the name of the framework integration that produced the\n exception, while for native it is e.g. `\"minidump\"` or `\"applecrashreport\"`.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "Message": {
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "MonitorContext": {
+      "description": " Monitor information.",
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": true
+        }
+      ]
+    },
+    "OsContext": {
+      "description": " Operating system information.\n\n OS context describes the operating system on which the event was created. In web contexts, this\n is the operating system of the browser (generally pulled from the User-Agent string).",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "build": {
+              "description": " Internal build number of the operating system.",
+              "type": ["string", "null"]
+            },
+            "kernel_version": {
+              "description": " Current kernel version.\n\n This is typically the entire output of the `uname` syscall.",
+              "type": ["string", "null"]
+            },
+            "name": {
+              "description": " Name of the operating system.",
+              "type": ["string", "null"]
+            },
+            "raw_description": {
+              "description": " Unprocessed operating system info.\n\n An unprocessed description string obtained by the operating system. For some well-known\n runtimes, Sentry will attempt to parse `name` and `version` from this string, if they are\n not explicitly given.",
+              "type": ["string", "null"]
+            },
+            "rooted": {
+              "description": " Indicator if the OS is rooted (mobile mostly).",
+              "type": ["boolean", "null"]
+            },
+            "version": {
+              "description": " Version of the operating system.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "OtelContext": {
+      "description": " OpenTelemetry Context\n\n If an event has this context, it was generated from an OpenTelemetry signal (trace, metric, log).",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "description": " Attributes of the OpenTelemetry span that maps to a Sentry event.\n\n <https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/trace/v1/trace.proto#L174-L186>",
+              "type": ["object", "null"],
+              "additionalProperties": true
+            },
+            "resource": {
+              "description": " Information about an OpenTelemetry resource.\n\n <https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/resource/v1/resource.proto>",
+              "type": ["object", "null"],
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "ProfileContext": {
+      "description": " Profile context",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": ["profile_id"],
+          "properties": {
+            "profile_id": {
+              "description": " The profile ID.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/EventId"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "RawStacktrace": {
+      "description": " A stack trace of a single thread.\n\n A stack trace contains a list of frames, each with various bits (most optional) describing the\n context of that frame. Frames should be sorted from oldest to newest.\n\n For the given example program written in Python:\n\n ```python\n def foo():\n     my_var = 'foo'\n     raise ValueError()\n\n def main():\n     foo()\n ```\n\n A minimalistic stack trace for the above program in the correct order:\n\n ```json\n {\n   \"frames\": [\n     {\"function\": \"main\"},\n     {\"function\": \"foo\"}\n   ]\n }\n ```\n\n The top frame fully symbolicated with five lines of source context:\n\n ```json\n {\n   \"frames\": [{\n     \"in_app\": true,\n     \"function\": \"myfunction\",\n     \"abs_path\": \"/real/file/name.py\",\n     \"filename\": \"file/name.py\",\n     \"lineno\": 3,\n     \"vars\": {\n       \"my_var\": \"'value'\"\n     },\n     \"pre_context\": [\n       \"def foo():\",\n       \"  my_var = 'foo'\",\n     ],\n     \"context_line\": \"  raise ValueError()\",\n     \"post_context\": [\n       \"\",\n       \"def main():\"\n     ],\n   }]\n }\n ```\n\n A minimal native stack trace with register values. Note that the `package` event attribute must\n be \"native\" for these frames to be symbolicated.\n\n ```json\n {\n   \"frames\": [\n     {\"instruction_addr\": \"0x7fff5bf3456c\"},\n     {\"instruction_addr\": \"0x7fff5bf346c0\"},\n   ],\n   \"registers\": {\n     \"rip\": \"0x00007ff6eef54be2\",\n     \"rsp\": \"0x0000003b710cd9e0\"\n   }\n }\n ```",
+      "type": "object",
+      "required": ["frames"],
+      "properties": {
+        "frames": {
+          "description": " Required. A non-empty list of stack frames. The list is ordered from caller to callee, or\n oldest to youngest. The last frame is the one creating the exception.",
+          "type": ["array", "null"],
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Frame"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "instruction_addr_adjustment": {
+          "description": " Optional. A flag that indicates if, and how, `instruction_addr` values need to be adjusted\n before they are symbolicated.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InstructionAddrAdjustment"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "lang": {
+          "description": " The language of the stacktrace.",
+          "type": ["string", "null"]
+        },
+        "registers": {
+          "description": " Register values of the thread (top frame).\n\n A map of register names and their values. The values should contain the actual register\n values of the thread, thus mapping to the last frame in the list.",
+          "type": ["object", "null"],
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RegVal"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "snapshot": {
+          "description": " Indicates that this stack trace is a snapshot triggered by an external signal.\n\n If this field is `false`, then the stack trace points to the code that caused this stack\n trace to be created. This can be the location of a raised exception, as well as an exception\n or signal handler.\n\n If this field is `true`, then the stack trace was captured as part of creating an unrelated\n event. For example, a thread other than the crashing thread, or a stack trace computed as a\n result of an external kill signal.",
+          "type": ["boolean", "null"]
+        }
+      },
+      "additionalProperties": true
+    },
+    "RegVal": {
+      "type": "string"
+    },
+    "Request": {
+      "title": "sentry_request",
+      "description": " Http request information.\n\n The Request interface contains information on a HTTP request related to the event. In client\n SDKs, this can be an outgoing request, or the request that rendered the current web page. On\n server SDKs, this could be the incoming web request that is being handled.\n\n The data variable should only contain the request body (not the query string). It can either be\n a dictionary (for standard HTTP requests) or a raw request body.\n\n ### Ordered Maps\n\n In the Request interface, several attributes can either be declared as string, object, or list\n of tuples. Sentry attempts to parse structured information from the string representation in\n such cases.\n\n Sometimes, keys can be declared multiple times, or the order of elements matters. In such\n cases, use the tuple representation over a plain object.\n\n Example of request headers as object:\n\n ```json\n {\n   \"content-type\": \"application/json\",\n   \"accept\": \"application/json, application/xml\"\n }\n ```\n\n Example of the same headers as list of tuples:\n\n ```json\n [\n   [\"content-type\", \"application/json\"],\n   [\"accept\", \"application/json\"],\n   [\"accept\", \"application/xml\"]\n ]\n ```\n\n Example of a fully populated request object:\n\n ```json\n {\n   \"request\": {\n     \"method\": \"POST\",\n     \"url\": \"http://absolute.uri/foo\",\n     \"query_string\": \"query=foobar&page=2\",\n     \"data\": {\n       \"foo\": \"bar\"\n     },\n     \"cookies\": \"PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;\",\n     \"headers\": {\n       \"content-type\": \"text/html\"\n     },\n     \"env\": {\n       \"REMOTE_ADDR\": \"192.168.0.1\"\n     }\n   }\n }\n ```",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "headers": {
+              "description": " A dictionary of submitted headers.\n\n If a header appears multiple times it, needs to be merged according to the HTTP standard\n for header merging. Header names are treated case-insensitively by Sentry.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Headers"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "method": {
+              "description": " HTTP request method.",
+              "type": ["string", "null"]
+            },
+            "url": {
+              "description": " The URL of the request if available.\n\nThe query string can be declared either as part of the `url`, or separately in `query_string`.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "ResponseContext": {
+      "description": " Response interface that contains information on a HTTP response related to the event.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "body_size": {
+              "description": " HTTP response body size.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "cookies": {
+              "description": " The cookie values.\n\n Can be given unparsed as string, as dictionary, or as a list of tuples.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Cookies"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "headers": {
+              "description": " A dictionary of submitted headers.\n\n If a header appears multiple times it, needs to be merged according to the HTTP standard\n for header merging. Header names are treated case-insensitively by Sentry.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Headers"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status_code": {
+              "description": " HTTP status code.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "RuntimeContext": {
+      "description": " Runtime information.\n\n Runtime context describes a runtime in more detail. Typically, this context is present in\n `contexts` multiple times if multiple runtimes are involved (for instance, if you have a\n JavaScript application running on top of JVM).",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "build": {
+              "description": " Application build string, if it is separate from the version.",
+              "type": ["string", "null"]
+            },
+            "name": {
+              "description": " Runtime name.",
+              "type": ["string", "null"]
+            },
+            "raw_description": {
+              "description": " Unprocessed runtime info.\n\n An unprocessed description string obtained by the runtime. For some well-known runtimes,\n Sentry will attempt to parse `name` and `version` from this string, if they are not\n explicitly given.",
+              "type": ["string", "null"]
+            },
+            "version": {
+              "description": " Runtime version string.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "SpanId": {
+      "description": " A 16-character hex string as described in the W3C trace context spec.",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "SpanStatus": {
+      "description": "Trace status.\n\nValues from <https://github.com/open-telemetry/opentelemetry-specification/blob/8fb6c14e4709e75a9aaa64b0dbbdf02a6067682a/specification/api-tracing.md#status> Mapping to HTTP from <https://github.com/open-telemetry/opentelemetry-specification/blob/8fb6c14e4709e75a9aaa64b0dbbdf02a6067682a/specification/data-http.md#status>",
+      "type": "string",
+      "enum": [
+        "ok",
+        "cancelled",
+        "unknown",
+        "invalid_argument",
+        "deadline_exceeded",
+        "not_found",
+        "already_exists",
+        "permission_denied",
+        "resource_exhausted",
+        "failed_precondition",
+        "aborted",
+        "out_of_range",
+        "unimplemented",
+        "internal_error",
+        "unavailable",
+        "data_loss",
+        "unauthenticated"
+      ]
+    },
+    "Stacktrace": {
+      "$ref": "#/definitions/RawStacktrace"
+    },
+    "String": {
+      "type": "string"
+    },
+    "SystemSdkInfo": {
+      "description": " Holds information about the system SDK.\n\n This is relevant for iOS and other platforms that have a system\n SDK.  Not to be confused with the client SDK.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "sdk_name": {
+              "description": " The internal name of the SDK.",
+              "type": ["string", "null"]
+            },
+            "version_major": {
+              "description": " The major version of the SDK as integer or 0.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "version_minor": {
+              "description": " The minor version of the SDK as integer or 0.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "version_patchlevel": {
+              "description": " The patch version of the SDK as integer or 0.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "TagEntry": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": [
+            {
+              "type": ["string", "null"]
+            },
+            {
+              "type": ["string", "null"]
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2
+        },
+        { "type": "null" }
+      ]
+    },
+    "Tags": {
+      "description": " Manual key/value tag pairs.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/TagEntry"
+      }
+    },
+    "ThreadId": {
+      "description": " Represents a thread id.",
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "Timestamp": {
+      "description": "Can be a ISO-8601 formatted string or a unix timestamp in seconds (floating point values allowed).\n\nMust be UTC.",
+      "anyOf": [
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "TraceContext": {
+      "description": " Trace context",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": ["span_id", "trace_id"],
+          "properties": {
+            "client_sample_rate": {
+              "description": " The client-side sample rate as reported in the envelope's `trace.sample_rate` header.\n\n The server takes this field from envelope headers and writes it back into the event. Clients\n should not ever send this value.",
+              "type": ["number", "null"]
+            },
+            "exclusive_time": {
+              "description": " The amount of time in milliseconds spent in this transaction span,\n excluding its immediate child spans.",
+              "type": ["number", "null"]
+            },
+            "op": {
+              "description": " Span type (see `OperationType` docs).",
+              "type": ["string", "null"]
+            },
+            "parent_span_id": {
+              "description": " The ID of the span enclosing this span.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SpanId"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "span_id": {
+              "description": " The ID of the span.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SpanId"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "description": " Whether the trace failed or succeeded. Currently only used to indicate status of individual\n transactions.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SpanStatus"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "trace_id": {
+              "description": " The trace ID.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/TraceId"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "sampled": {
+              "description": " Whether the trace connected to the event has been sampled as part of dynamic sampling",
+              "type": ["boolean", "null"]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "TraceId": {
+      "description": " A 32-character hex string as described in the W3C trace context spec.",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "TransactionInfo": {
+      "description": " Additional information about the name of the transaction.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "source": {
+              "description": " Describes how the name of the transaction was determined.\n\n This will be used by the server to decide whether or not to scrub identifiers from the\n transaction name, or replace the entire name with a placeholder.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "TransactionSource": {
+      "description": "Describes how the name of the transaction was determined.",
+      "type": "string"
+    },
+    "User": {
+      "title": "sentry_user",
+      "description": " Information about the user who triggered an event.\n\n ```json\n {\n   \"user\": {\n     \"id\": \"unique_id\",\n     \"username\": \"my_user\",\n     \"email\": \"foo@example.com\",\n     \"ip_address\": \"127.0.0.1\",\n     \"subscription\": \"basic\"\n   }\n }\n ```",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "description": " Additional arbitrary fields, as stored in the database (and sometimes as sent by clients).\n All data from `self.other` should end up here after store normalization.",
+              "type": ["object", "null"],
+              "additionalProperties": true
+            },
+            "email": {
+              "description": " Email address of the user.",
+              "type": ["string", "null"]
+            },
+            "geo": {
+              "description": " Approximate geographical location of the end user or device.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Geo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "description": " Unique identifier of the user.",
+              "type": ["string", "null"]
+            },
+            "ip_address": {
+              "description": " Remote IP address of the user. Defaults to \"{{auto}}\".",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/String"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "name": {
+              "description": " Human readable name of the user.",
+              "type": ["string", "null"]
+            },
+            "segment": {
+              "description": " The user segment, for apps that divide users in user segments.",
+              "type": ["string", "null"]
+            },
+            "username": {
+              "description": " Username of the user.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    }
+  }
+}

--- a/topics/generic-events.yaml
+++ b/topics/generic-events.yaml
@@ -10,6 +10,6 @@ schemas:
   - version: 1
     compatibility_mode: none
     type: json
-    resource: events.v1.schema.json
+    resource: generic-events.v1.schema.json
     examples:
       - generic-events/1/


### PR DESCRIPTION
The example introduced in https://github.com/getsentry/sentry-kafka-schemas/pull/154 was wrong. Generic events needs "occurrence_id" and "occurrence_data".

Created a separate schema for generic-events. It's similar to events with these differences:
- occurrence_id
- occurrence_data
- only inserts, no replacement types