### PR TITLE
fix(ingest-replay-events): Type is not required

### DIFF
--- a/schemas/ingest-replay-events.v1.schema.json
+++ b/schemas/ingest-replay-events.v1.schema.json
@@ -34,8 +34,7 @@
         "project_id",
         "replay_id",
         "retention_days",
-        "start_time",
-        "type"
+        "start_time"
       ]
     }
   }


### PR DESCRIPTION
Consumer pulls type out of the deserialized payload, it's not a required top level property and is not always being populated. ref: https://github.com/getsentry/snuba/blob/dea5838d3cffe3dfaeed0ab5c956f7b578affd1a/snuba/datasets/processors/replays_processor.py#L178-L192