### PR TITLE
feat(group-attributes): add new topic and schema for group attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 target
 /python/sentry_kafka_schemas/schema_types/
 node_modules/
+.idea/

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,14 +13,17 @@
 /topics/ingest-replay-events.yaml                          @getsentry/owners-snuba @getsentry/replay
 /topics/processed-profiles.yaml                            @getsentry/owners-snuba @getsentry/profiling
 /topics/profiles-call-tree.yaml                            @getsentry/owners-snuba @getsentry/profiling
+/topics/group-attributes.yaml                              @getsentry/owners-snuba @getsentry/issues
 
 # Schemas
 /schemas/profile-metadata.v1.schema.json                   @getsentry/profiling
 /schemas/profile-functions.v1.schema.json                  @getsentry/profiling
+/schemas/group-attributes.v1.schema.json                   @getsentry/issues
 
 # Examples
 /examples/profile-metadata/                                @getsentry/profiling
 /examples/profile-functions/                               @getsentry/profiling
+/examples/group-attributes/                                @getsentry/issues
 
 # Internal Snuba topics
 /topics/snuba-queries.yaml                                 @getsentry/owners-snuba

--- a/examples/group-attributes/1/assignee_changed.json
+++ b/examples/group-attributes/1/assignee_changed.json
@@ -1,0 +1,17 @@
+{
+  "group_deleted": false,
+  "project_id": 1,
+  "group_id": 1,
+  "status": 0,
+  "substatus": 7,
+  "first_seen": "2023-02-27T15:40:12.223000Z",
+  "num_comments": 0,
+  "assignee_user_id": 123,
+  "assignee_team_id": null,
+  "owner_suspect_commit_user_id": null,
+  "owner_ownership_rule_user_id": null,
+  "owner_ownership_rule_team_id": null,
+  "owner_codeowners_user_id": null,
+  "owner_codeowners_team_id": null,
+  "timestamp": "2023-02-27T15:41:12.000000Z"
+}

--- a/examples/group-attributes/1/group_created.json
+++ b/examples/group-attributes/1/group_created.json
@@ -1,0 +1,17 @@
+{
+  "group_deleted": false,
+  "project_id": 1,
+  "group_id": 1,
+  "status": 0,
+  "substatus": 7,
+  "first_seen": "2023-02-27T15:40:12.223000Z",
+  "num_comments": 0,
+  "assignee_user_id": null,
+  "assignee_team_id": null,
+  "owner_suspect_commit_user_id": null,
+  "owner_ownership_rule_user_id": null,
+  "owner_ownership_rule_team_id": null,
+  "owner_codeowners_user_id": null,
+  "owner_codeowners_team_id": null,
+  "timestamp": "2023-02-27T15:40:12.223000Z"
+}

--- a/examples/group-attributes/1/group_deleted.json
+++ b/examples/group-attributes/1/group_deleted.json
@@ -1,0 +1,17 @@
+{
+  "group_deleted": true,
+  "project_id": 1,
+  "group_id": 1,
+  "status": 4,
+  "substatus": null,
+  "first_seen": "2023-02-27T15:40:12.223000Z",
+  "num_comments": 0,
+  "assignee_user_id": null,
+  "assignee_team_id": null,
+  "owner_suspect_commit_user_id": null,
+  "owner_ownership_rule_user_id": null,
+  "owner_ownership_rule_team_id": null,
+  "owner_codeowners_user_id": null,
+  "owner_codeowners_team_id": null,
+  "timestamp": "2023-02-27T15:42:12.000000Z"
+}

--- a/examples/group-attributes/1/owner_changed.json
+++ b/examples/group-attributes/1/owner_changed.json
@@ -1,0 +1,17 @@
+{
+  "group_deleted": false,
+  "project_id": 1,
+  "group_id": 1,
+  "status": 0,
+  "substatus": 7,
+  "first_seen": "2023-02-27T15:40:12.223000Z",
+  "num_comments": 0,
+  "assignee_user_id": 123,
+  "assignee_team_id": null,
+  "owner_suspect_commit_user_id": null,
+  "owner_ownership_rule_user_id": null,
+  "owner_ownership_rule_team_id": 456,
+  "owner_codeowners_user_id": null,
+  "owner_codeowners_team_id": null,
+  "timestamp": "2023-02-27T15:41:22.000000Z"
+}

--- a/schemas/group-attributes.v1.schema.json
+++ b/schemas/group-attributes.v1.schema.json
@@ -19,10 +19,7 @@
           "type": "integer"
         },
         "substatus": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "first_seen": {
           "type": "string"
@@ -31,46 +28,25 @@
           "type": "integer"
         },
         "assignee_user_id": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "assignee_team_id": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "owner_suspect_commit_user_id": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "owner_ownership_rule_user_id": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "owner_ownership_rule_team_id": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "owner_codeowners_user_id": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "owner_codeowners_team_id": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "timestamp": {
           "type": "string"

--- a/schemas/group-attributes.v1.schema.json
+++ b/schemas/group-attributes.v1.schema.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$ref": "#/definitions/GroupAttributesSnapshot",
-  "title": "group_attributes",
   "definitions": {
     "GroupAttributesSnapshot": {
       "type": "object",
+      "title": "group_attributes_snapshot",
       "properties": {
         "group_deleted": {
           "type": "boolean"

--- a/schemas/group-attributes.v1.schema.json
+++ b/schemas/group-attributes.v1.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/GroupAttributesSnapshot",
+  "title": "group_attributes",
+  "definitions": {
+    "GroupAttributesSnapshot": {
+      "type": "object",
+      "properties": {
+        "group_deleted": {
+          "type": "boolean"
+        },
+        "project_id": {
+          "type": "integer"
+        },
+        "group_id": {
+          "type": "integer"
+        },
+        "status": {
+          "type": "integer"
+        },
+        "substatus": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "first_seen": {
+          "type": "string"
+        },
+        "num_comments": {
+          "type": "integer"
+        },
+        "assignee_user_id": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "assignee_team_id": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "owner_suspect_commit_user_id": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "owner_ownership_rule_user_id": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "owner_ownership_rule_team_id": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "owner_codeowners_user_id": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "owner_codeowners_team_id": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "timestamp": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "group_deleted",
+        "project_id",
+        "group_id",
+        "status",
+        "substatus",
+        "first_seen",
+        "num_comments",
+        "assignee_user_id",
+        "assignee_team_id",
+        "owner_suspect_commit_user_id",
+        "owner_ownership_rule_user_id",
+        "owner_ownership_rule_team_id",
+        "owner_codeowners_user_id",
+        "owner_codeowners_team_id",
+        "timestamp"
+      ]
+    }
+  }
+}

--- a/topics/group-attributes.yaml
+++ b/topics/group-attributes.yaml
@@ -1,0 +1,14 @@
+topic: group-attributes
+description: A snapshot of Group/Issue attributes replicated from sentry
+services:
+  producers:
+    - getsentry/sentry
+  consumers:
+    - getsentry/snuba
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: json
+    resource: group-attributes.v1.schema.json
+    examples:
+      - group-attributes/1/


### PR DESCRIPTION
Define a new message type for replicating a subset of attributes from the Group, GroupAssignee, and GroupOwner postgres tables to snuba.

