### PR TITLE
feat: Mark required fields in querylog

### DIFF
--- a/schemas/snuba-queries.v1.schema.json
+++ b/schemas/snuba-queries.v1.schema.json
@@ -84,6 +84,7 @@
           }
         }
       },
+      "required": ["timestamp", "duration_ms"],
       "additionalProperties": true
     },
     "snql_anonymized": {


### PR DESCRIPTION
These are always present and are required since https://github.com/getsentry/snuba/pull/4511