### PR TITLE
feat(generic-metrics): Add `aggregation_option` field to metrics

### DIFF
--- a/schemas/snuba-generic-metrics.v1.schema.json
+++ b/schemas/snuba-generic-metrics.v1.schema.json
@@ -60,6 +60,9 @@
         },
         "mapping_meta": {
           "$ref": "#/definitions/MappingMeta"
+        },
+        "aggregation_option": {
+          "type": "string"
         }
       },
       "required": [


### PR DESCRIPTION
### Overview

Adding an optional field `aggregation_option` to metric messages so each message can encode special aggregation that needs to be performed on it.
For instance, an `aggregation_option` may be `STD_HIST`, this indicate to the snuba consumer to set the `enable_histogram` field to `1` so that histogram aggregation can be applied.