### PR TITLE
feat(querylog): Add schema definition for stats object

### DIFF
--- a/schemas/snuba-queries.v1.schema.json
+++ b/schemas/snuba-queries.v1.schema.json
@@ -127,7 +127,33 @@
           "type": ["integer", "null"]
         },
         "stats": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "final": {
+              "type": "boolean"
+            },
+            "cache_hit": {
+              "type": "integer"
+            },
+            "sample": {
+              "type": "number"
+            },
+            "max_threads": {
+              "type": "integer"
+            },
+            "clickhouse_table": {
+              "type": "string"
+            },
+            "query_id": {
+              "type": "string"
+            },
+            "is_duplicate": {
+              "type": "integer"
+            },
+            "consistent": {
+              "type": "boolean"
+            }
+          }
         },
         "status": {
           "type": "string"

--- a/schemas/snuba-queries.v1.schema.json
+++ b/schemas/snuba-queries.v1.schema.json
@@ -136,7 +136,7 @@
               "type": "integer"
             },
             "sample": {
-              "type": "number"
+              "type": ["number", "null"]
             },
             "max_threads": {
               "type": "integer"


### PR DESCRIPTION
We are currently porting the querylog processor from Python to Rust, and checking the codebase to figure out what these types were supposed to be was very tricky. Let's add them to the schema.