### PR TITLE
Revert "Add spans data schema (#153)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ The yaml file of a topic has 2 keys:
 ## Using the schema (in Python)
 
 ```python
-from sentry_kafka_schemas import get_codec
-from sentry_kafka_schemas.codecs import ValidationError
+from sentry_kafka_schemas import get_codec, ValidationError
 from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 
 SCHEMA: Codec[IngestMetric] = get_codec("ingest-metrics")

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "transaction_stream_message",
   "type": "array",
   "items": [
     { "const": 2 },
@@ -978,7 +977,7 @@
           "type": ["object", "null"]
         },
         "data": {
-          "anyOf": [{ "$ref": "#/definitions/SpanData" }, { "type": "null" }]
+          "type": ["object", "null"]
         },
         "hash": {
           "type": "string"
@@ -1108,60 +1107,6 @@
           "properties": {
             "source": {
               "description": "Describes how the name of the transaction was determined.\n\n This will be used by the server to decide whether or not to scrub identifiers from the\n transaction name, or replace the entire name with a placeholder.",
-              "type": ["string", "null"]
-            }
-          },
-          "additionalProperties": true
-        }
-      ]
-    },
-    "SpanData": {
-      "description": "Spans data bag",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "environment": {
-              "type": ["string", "null"]
-            },
-            "http.method": {
-              "type": ["string", "null"]
-            },
-            "span.action": {
-              "type": ["string", "null"]
-            },
-            "span.domain": {
-              "type": ["string", "null"]
-            },
-            "span.module": {
-              "type": ["string", "null"]
-            },
-            "span.op": {
-              "type": ["string", "null"]
-            },
-            "span.group": {
-              "description": "hex hash of the scrubbed span description",
-              "type": ["string", "null"]
-            },
-            "span.status": {
-              "type": ["string", "null"]
-            },
-            "span.system": {
-              "type": ["string", "null"]
-            },
-            "span.status_code": {
-              "type": ["integer", "null"]
-            },
-            "status_code": {
-              "type": ["integer", "null"]
-            },
-            "transaction": {
-              "type": ["string", "null"]
-            },
-            "transaction.op": {
-              "type": ["string", "null"]
-            },
-            "transaction.method": {
               "type": ["string", "null"]
             }
           },


### PR DESCRIPTION
This reverts commit d288a50e9447650067d914f37cf964a2ed68839c.

This was added because spans was part of transactions in the initial implementation. It is a separate topic now.

This schema seems to be causing issues in prod since not all transactions events actually conform to it.