### PR TITLE
Allow new `nel` event type in events topics

### DIFF
--- a/schemas/events.v1.schema.json
+++ b/schemas/events.v1.schema.json
@@ -1086,6 +1086,7 @@
         "expectct",
         "expectstaple",
         "transaction",
+        "nel",
         "default"
       ]
     },

--- a/schemas/generic-events.v1.schema.json
+++ b/schemas/generic-events.v1.schema.json
@@ -828,6 +828,7 @@
         "expectct",
         "expectstaple",
         "transaction",
+        "nel",
         "default",
         "generic"
       ]


### PR DESCRIPTION
Prerequisite for https://github.com/getsentry/sentry/pull/55135 (Network Error Logging).
No extra validation yet (I don't see any extra validation for `csp` either). This should unblock local testing etc.