### PR TITLE
fix(spans): Remove wrong array type

### DIFF
--- a/schemas/snuba-spans.v1.schema.json
+++ b/schemas/snuba-spans.v1.schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "spans_stream_message",
-  "type": "array",
   "$ref": "#/definitions/SpanEvent",
   "definitions": {
     "SpanEvent": {


### PR DESCRIPTION
We're expecting an object at a time, not an array of spans.