### PR TITLE
feat(feedback): add feedback as new event type

### DIFF
--- a/schemas/events.v1.schema.json
+++ b/schemas/events.v1.schema.json
@@ -1077,7 +1077,7 @@
       ]
     },
     "EventType": {
-      "description": "The type of an event.\n\nThe event type determines how Sentry handles the event and has an impact on processing, rate limiting, and quotas. There are three fundamental classes of event types:\n\n- **Error monitoring events** (`default`, `error`): Processed and grouped into unique issues based on their exception stack traces and error messages. - **Security events** (`csp`, `hpkp`, `expectct`, `expectstaple`): Derived from Browser security violation reports and grouped into unique issues based on the endpoint and violation. SDKs do not send such events. - **Transaction events** (`transaction`): Contain operation spans and collected into traces for performance monitoring.",
+      "description": "The type of an event.\n\nThe event type determines how Sentry handles the event and has an impact on processing, rate limiting, and quotas. There are three fundamental classes of event types:\n\n- **Error monitoring events** (`default`, `error`): Processed and grouped into unique issues based on their exception stack traces and error messages. - **Security events** (`csp`, `hpkp`, `expectct`, `expectstaple`): Derived from Browser security violation reports and grouped into unique issues based on the endpoint and violation. SDKs do not send such events. - **Transaction events** (`transaction`): Contain operation spans and collected into traces for performance monitoring. - **Feedback events** (`feedback`): Contains user feedback messages.",
       "type": "string",
       "enum": [
         "error",
@@ -1087,7 +1087,8 @@
         "expectstaple",
         "transaction",
         "nel",
-        "default"
+        "default",
+        "feedback"
       ]
     },
     "ExceptionChain": {

--- a/schemas/generic-events.v1.schema.json
+++ b/schemas/generic-events.v1.schema.json
@@ -819,7 +819,7 @@
       ]
     },
     "EventType": {
-      "description": "The type of an event.\n\nThe event type determines how Sentry handles the event and has an impact on processing, rate limiting, and quotas. There are three fundamental classes of event types:\n\n- **Error monitoring events** (`default`, `error`): Processed and grouped into unique issues based on their exception stack traces and error messages. - **Security events** (`csp`, `hpkp`, `expectct`, `expectstaple`): Derived from Browser security violation reports and grouped into unique issues based on the endpoint and violation. SDKs do not send such events. - **Transaction events** (`transaction`): Contain operation spans and collected into traces for performance monitoring.",
+      "description": "The type of an event.\n\nThe event type determines how Sentry handles the event and has an impact on processing, rate limiting, and quotas. There are three fundamental classes of event types:\n\n- **Error monitoring events** (`default`, `error`): Processed and grouped into unique issues based on their exception stack traces and error messages. - **Security events** (`csp`, `hpkp`, `expectct`, `expectstaple`): Derived from Browser security violation reports and grouped into unique issues based on the endpoint and violation. SDKs do not send such events. - **Transaction events** (`transaction`): Contain operation spans and collected into traces for performance monitoring. - **Feedback events** (`feedback`): Contains user feedback messages.",
       "type": "string",
       "enum": [
         "error",
@@ -830,7 +830,8 @@
         "transaction",
         "nel",
         "default",
-        "generic"
+        "generic",
+        "feedback"
       ]
     },
     "ExceptionChain": {


### PR DESCRIPTION
- Adds the feedback event type. See https://github.com/getsentry/team-replay/issues/222
- We'll be leveraging the issue platform to create issues, and these feedbacks will flow in from relay on the events topic and be picked up in the ingest consumer and have issues created via issue platform, which is why we need the event type on both.