### PR TITLE
fix: Make gauges a possible value in Snuba RH topic

### DIFF
--- a/schemas/snuba-metrics.v1.schema.json
+++ b/schemas/snuba-metrics.v1.schema.json
@@ -57,6 +57,7 @@
             },
             {
               "title": "gauge_metric_value",
+              "description": "This type is NOT yet supported in Release Health. However, since the upstream (ingest-metrics) schema is shared between Generic Metrics and Release Health, we add this as a possible value for type checking and compatibility.",
               "type": "object",
               "properties": {
                 "min": {

--- a/schemas/snuba-metrics.v1.schema.json
+++ b/schemas/snuba-metrics.v1.schema.json
@@ -76,13 +76,7 @@
                 }
               },
               "additionalProperties": false,
-              "required": [
-                "min",
-                "max",
-                "sum",
-                "count",
-                "last"
-              ]
+              "required": ["min", "max", "sum", "count", "last"]
             }
           ]
         },

--- a/schemas/snuba-metrics.v1.schema.json
+++ b/schemas/snuba-metrics.v1.schema.json
@@ -7,7 +7,9 @@
       "type": "object",
       "additionalProperties": true,
       "properties": {
-        "version": { "const": 1 },
+        "version": {
+          "const": 1
+        },
         "use_case_id": {
           "type": "string"
         },
@@ -52,6 +54,35 @@
               "items": {
                 "type": "number"
               }
+            },
+            {
+              "title": "gauge_metric_value",
+              "type": "object",
+              "properties": {
+                "min": {
+                  "type": "number"
+                },
+                "max": {
+                  "type": "number"
+                },
+                "sum": {
+                  "type": "number"
+                },
+                "count": {
+                  "type": "integer"
+                },
+                "last": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "min",
+                "max",
+                "sum",
+                "count",
+                "last"
+              ]
             }
           ]
         },


### PR DESCRIPTION
The schema for Snuba release health/metrics topic is not flexible enough currently to support the shared upstream ingest metrics topic schema. This adds gauges as a **possible** value to the release health topic, though it is not actually supported in release health. 

The upstream schema (ingest-metrics) is shared between BOTH generic metrics and release health, and as a result, we are noticing typing problems in Sentry codebase which we are not able to simply ignore. 