### PR TITLE
fix(rust): Fix spurious topic-not-found due to wrong sorting key

### DIFF
--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -188,6 +188,7 @@ mod tests {
 
         // Did not error
         get_schema("snuba-queries", Some(1)).unwrap();
+        get_schema("transactions", Some(1)).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
In code generation, we create a sorted list of topics called TOPICS
containing key-value pairs, and then later use binary search to find an
entry by key. We don't use maps because those cannot be created at compile
time, only arrays.

Unfortunately we used a different key in each process. So we sorted by a
value like "transactions.yaml" when creating the list, but the row reads
like this:

    [
        ...
        ("transactions", "<yaml contents>"),

so the lookup happens on a value like "transactions". This is not a big
difference, but it matters because we also have
"transactions-subscription-results", which sorts after "transactions",
but before "transactions.yaml"

Refactor the build.rs so that a consistent sorting order is used, and
add a test for "tranasctions" specifically which previously would always
return "topic not found"
