### PR TITLE
ref(rust): Add example name to examples

### DIFF
--- a/rust/build.rs
+++ b/rust/build.rs
@@ -75,7 +75,7 @@ fn generate_embedded_data() -> String {
     writeln!(w, "];").unwrap();
 
     let mut last_prefix = None;
-    writeln!(w, "const EXAMPLES: &[(&str, &[&[u8]])] = &[").unwrap();
+    writeln!(w, "const EXAMPLES: &[(&str, &[crate::Example])] = &[").unwrap();
     let key_fn = |example: &String| {
         let last_slash = example.rfind('/').unwrap();
         let (prefix, _name) = example.split_at(last_slash + 1);
@@ -97,7 +97,11 @@ fn generate_embedded_data() -> String {
         }
         last_prefix = Some(prefix);
         let path = format!("{manifest_root}/examples/{example}");
-        writeln!(w, "        include_bytes!({path:?}),").unwrap();
+        writeln!(
+            w,
+            "        crate::Example {{ name: {example:?}, payload: include_bytes!({path:?}) }},"
+        )
+        .unwrap();
     }
     writeln!(w, "    ]),").unwrap();
     writeln!(w, "];").unwrap();

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -214,7 +214,7 @@ mod tests {
         let examples = schema.examples();
         assert!(!examples.is_empty());
         for example in examples {
-            schema.validate_json(example).unwrap();
+            schema.validate_json(example.payload()).unwrap();
         }
 
         assert!(matches!(

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -77,7 +77,7 @@ pub struct Schema {
     pub compatibility_mode: CompatibilityMode,
     schema: &'static str,
     compiled_json_schema: JSONSchema,
-    examples: &'static [&'static [u8]],
+    examples: &'static [Example],
 }
 
 impl PartialEq for Schema {
@@ -106,8 +106,24 @@ impl Schema {
     }
 
     /// Returns a list of examples for this schema.
-    pub fn examples(&self) -> &[&[u8]] {
+    pub fn examples(&self) -> &[Example] {
         self.examples
+    }
+}
+
+#[derive(Debug)]
+pub struct Example {
+    name: &'static str,
+    payload: &'static [u8],
+}
+
+impl Example {
+    pub fn name(&self) -> &str {
+        self.name
+    }
+
+    pub fn payload(&self) -> &[u8] {
+        self.payload
     }
 }
 


### PR DESCRIPTION
This came up in https://github.com/getsentry/snuba/pull/5451 where I had
to approve a ton of snapshot tests, because the examples there got
reordered. I want to name those snapshot files after the filename in
sentry-kafka-schemas (instead of an integer) so this is easier to debug.
