### PR TITLE
feat(replays): add replay event to recording schema

### DIFF
--- a/schemas/ingest-replay-recordings.v1.schema.json
+++ b/schemas/ingest-replay-recordings.v1.schema.json
@@ -12,6 +12,7 @@
     "received": { "type": "integer", "minimum": 0 },
     "retention_days": { "type": "integer" },
     "payload": { "description": "msgpack bytes" },
+    "replay_event": { "description": "JSON bytes" },
     "version": { "type": "integer", "default": 0 }
   },
   "required": [


### PR DESCRIPTION
We're now sending the replay_event to the recording consumer on an optional key. Produced in https://github.com/getsentry/relay/pull/3035, recording consumer change forthcoming 