### PR TITLE
feat(replays): Add replay-video attribute to recording message

### DIFF
--- a/schemas/ingest-replay-recordings.v1.schema.json
+++ b/schemas/ingest-replay-recordings.v1.schema.json
@@ -11,10 +11,7 @@
       "type": "string"
     },
     "key_id": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "org_id": {
       "type": "integer",

--- a/schemas/ingest-replay-recordings.v1.schema.json
+++ b/schemas/ingest-replay-recordings.v1.schema.json
@@ -4,16 +4,46 @@
   "description": "A replay recording, or a chunk thereof",
   "type": "object",
   "properties": {
-    "type": { "const": "replay_recording_not_chunked" },
-    "replay_id": { "type": "string" },
-    "key_id": { "type": ["null", "integer"] },
-    "org_id": { "type": "integer", "minimum": 0 },
-    "project_id": { "type": "integer", "minimum": 0 },
-    "received": { "type": "integer", "minimum": 0 },
-    "retention_days": { "type": "integer" },
-    "payload": { "description": "msgpack bytes" },
-    "replay_event": { "description": "JSON bytes" },
-    "version": { "type": "integer", "default": 0 }
+    "type": {
+      "const": "replay_recording_not_chunked"
+    },
+    "replay_id": {
+      "type": "string"
+    },
+    "key_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "org_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "project_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "received": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "retention_days": {
+      "type": "integer"
+    },
+    "payload": {
+      "description": "msgpack bytes"
+    },
+    "replay_event": {
+      "description": "JSON bytes"
+    },
+    "replay_video": {
+      "description": "JSON bytes"
+    },
+    "version": {
+      "type": "integer",
+      "default": 0
+    }
   },
   "required": [
     "type",


### PR DESCRIPTION
VSCode insisted on auto-formatting and I'm too tired to argue with it anymore.  The only change is the replay-video field.