### PR TITLE
perf(gen-metrics): Remove value validation for indexer schema

### DIFF
--- a/schemas/ingest-metrics.v1.schema.json
+++ b/schemas/ingest-metrics.v1.schema.json
@@ -40,53 +40,7 @@
             "type": "string"
           }
         },
-        "value": {
-          "anyOf": [
-            {
-              "title": "counter_metric_value",
-              "type": "number"
-            },
-            {
-              "title": "set_metric_value",
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "minimum": 0,
-                "maximum": 4294967295
-              }
-            },
-            {
-              "title": "distribution_metric_value",
-              "type": "array",
-              "items": {
-                "type": "number"
-              }
-            },
-            {
-              "title": "gauge_metric_value",
-              "type": "object",
-              "properties": {
-                "min": {
-                  "type": "number"
-                },
-                "max": {
-                  "type": "number"
-                },
-                "sum": {
-                  "type": "number"
-                },
-                "count": {
-                  "type": "integer"
-                },
-                "last": {
-                  "type": "number"
-                }
-              },
-              "additionalProperties": false,
-              "required": ["min", "max", "sum", "count", "last"]
-            }
-          ]
-        },
+        "value": {},
         "retention_days": {
           "type": "integer",
           "minimum": 0,


### PR DESCRIPTION
### Overview

The indexer does not care about what the value field is, the validation for value should happen further down the pipeline. Updates the schema to remove value field constraints.