### PR TITLE
ref: Add team ops as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -68,5 +68,5 @@
 /schemas/subscription-result.v1.schema.json                   @getsentry/owners-snuba @getsentry/workflow
 /examples/subscription-results/                               @getsentry/owners-snuba @getsentry/workflow
 
-# Search and storage is the default owner
-* @getsentry/owners-snuba
+# Search and storage and infra is the default owner
+* @getsentry/owners-snuba @getsentry/team-ops

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -69,4 +69,4 @@
 /examples/subscription-results/                               @getsentry/owners-snuba @getsentry/workflow
 
 # Search and storage and infra is the default owner
-* @getsentry/owners-snuba @getsentry/team-ops
+* @getsentry/owners-snuba @getsentry/ops


### PR DESCRIPTION
This project is imported by ops for kafka control plane now as prod config will be sync with it. team-ops should be owners too.