### PR TITLE
feat: Add retention values to DLQ

### DIFF
--- a/python/tests/test_sentry_kafka_schemas.py
+++ b/python/tests/test_sentry_kafka_schemas.py
@@ -9,7 +9,7 @@ def test_get_topic() -> None:
     assert topic_data["topic_creation_config"] == {"max.message.bytes": "2000000"}
 
     # Topic without creation config
-    topic_name_no_config = "snuba-dead-letter-replays"
+    topic_name_no_config = "outcomes"
     topic_data = get_topic(topic_name_no_config)
     assert topic_data["topic_creation_config"] == {}
 

--- a/topics/ingest-events-dlq.yaml
+++ b/topics/ingest-events-dlq.yaml
@@ -12,3 +12,5 @@ schemas:
     resource: any.json
     examples:
       - any/
+topic_creation_config:
+  log.retention.minutes: "10080"

--- a/topics/ingest-generic-metrics-dlq.yaml
+++ b/topics/ingest-generic-metrics-dlq.yaml
@@ -12,3 +12,5 @@ schemas:
     resource: any.json
     examples:
       - any/
+topic_creation_config:
+  log.retention.minutes: "10080"

--- a/topics/ingest-metrics-dlq.yaml
+++ b/topics/ingest-metrics-dlq.yaml
@@ -12,3 +12,5 @@ schemas:
     resource: any.json
     examples:
       - any/
+topic_creation_config:
+  log.retention.minutes: "10080"

--- a/topics/snuba-dead-letter-generic-metrics.yaml
+++ b/topics/snuba-dead-letter-generic-metrics.yaml
@@ -12,3 +12,5 @@ schemas:
     resource: any.json
     examples:
       - any/
+topic_creation_config:
+  log.retention.minutes: "10080"

--- a/topics/snuba-dead-letter-group-attributes.yaml
+++ b/topics/snuba-dead-letter-group-attributes.yaml
@@ -12,3 +12,5 @@ schemas:
     resource: any.json
     examples:
       - any/
+topic_creation_config:
+  log.retention.minutes: "10080"

--- a/topics/snuba-dead-letter-metrics.yaml
+++ b/topics/snuba-dead-letter-metrics.yaml
@@ -12,3 +12,5 @@ schemas:
     resource: any.json
     examples:
       - any/
+topic_creation_config:
+  log.retention.minutes: "10080"

--- a/topics/snuba-dead-letter-querylog.yaml
+++ b/topics/snuba-dead-letter-querylog.yaml
@@ -12,3 +12,5 @@ schemas:
     resource: any.json
     examples:
       - any/
+topic_creation_config:
+  log.retention.minutes: "10080"

--- a/topics/snuba-dead-letter-replays.yaml
+++ b/topics/snuba-dead-letter-replays.yaml
@@ -12,3 +12,5 @@ schemas:
     resource: any.json
     examples:
       - any/
+topic_creation_config:
+  log.retention.minutes: "10080"


### PR DESCRIPTION
DLQ retention is one week. This matches what we do across all DLQ topics in Sentry prod.