### PR TITLE
feat(metric-outcomes): Add initial topic and schema

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,6 +12,7 @@
 /topics/events.yaml                                            @getsentry/owners-snuba
 /topics/transactions.yaml                                      @getsentry/owners-snuba
 /topics/outcomes.yaml                                          @getsentry/owners-snuba
+/topics/outcomes-metrics.yaml                                  @getsentry/owners-snuba @getsentry/ingest
 /topics/outcomes-billing.yaml                                  @getsentry/owners-snuba
 /topics/snuba-metrics.yaml                                     @getsentry/owners-snuba
 /topics/snuba-generic-metrics.yaml                             @getsentry/owners-snuba

--- a/examples/outcomes-metrics/1/outcomes-metrics-full.json
+++ b/examples/outcomes-metrics/1/outcomes-metrics-full.json
@@ -1,0 +1,10 @@
+{
+  "timestamp": 1709812800,
+  "org_id": 1,
+  "project_id": 1,
+  "mri": "d:custom/request_duration@seconds",
+  "outcome": 2,
+  "reason": "foobar",
+  "quantity": 42,
+  "cardinality": 1337
+}

--- a/examples/outcomes-metrics/1/outcomes-metrics-only-cardinality.json
+++ b/examples/outcomes-metrics/1/outcomes-metrics-only-cardinality.json
@@ -1,0 +1,8 @@
+{
+  "timestamp": 1709812800,
+  "org_id": 1,
+  "project_id": 1,
+  "mri": "c:custom/clicks@none",
+  "outcome": 0,
+  "cardinality": 1337
+}

--- a/examples/outcomes-metrics/1/outcomes-metrics-only-volume.json
+++ b/examples/outcomes-metrics/1/outcomes-metrics-only-volume.json
@@ -1,0 +1,8 @@
+{
+  "timestamp": 1709812800,
+  "org_id": 1,
+  "project_id": 1,
+  "mri": "c:custom/clicks@none",
+  "outcome": 0,
+  "quantity": 1337
+}

--- a/schemas/outcomes-metrics.v1.schema.json
+++ b/schemas/outcomes-metrics.v1.schema.json
@@ -32,11 +32,11 @@
         },
         "quantity": {
           "description": "Amount of metric buckets accepted by Relay (volume).",
-          "type": "integer"
+          "$ref": "#/definitions/U64"
         },
         "cardinality": {
           "description": "Maximum observed cardinality of the metric.",
-          "type": "integer"
+          "$ref": "#/definitions/U64"
         }
       },
       "required": ["timestamp", "org_id", "project_id", "mri", "outcome"]

--- a/schemas/outcomes-metrics.v1.schema.json
+++ b/schemas/outcomes-metrics.v1.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "metrics-outcome",
+  "$ref": "#/definitions/MetricsOutcome",
+  "definitions": {
+    "MetricsOutcome": {
+      "properties": {
+        "timestamp": {
+          "description": "The UNIX timestamp in seconds when the outcome was created, optionally truncated to the last hour.",
+          "$ref": "#/definitions/U64"
+        },
+        "org_id": {
+          "description": "The organization for which this outcome is being sent.",
+          "$ref": "#/definitions/U64"
+        },
+        "project_id": {
+          "description": "The project for which this outcome is being sent.",
+          "$ref": "#/definitions/U64"
+        },
+        "mri": {
+          "description": "Valid metric resource identifier `<type>:<namespace>/<name>[@<unit>]` for which the outcome is being sent.",
+          "type": "string"
+        },
+        "outcome": {
+          "description": "Outcome ID, metric outcomes share the same numeric outcome ID with regular outcomes.",
+          "$ref": "#/definitions/U64"
+        },
+        "reason": {
+          "description": "Optional machine readable, free-form reason code.",
+          "type": ["string", "null"]
+        },
+        "quantity": {
+          "description": "Amount of metric buckets accepted by Relay (volume).",
+          "type": "integer"
+        },
+        "cardinality": {
+          "description": "Maximum observed cardinality of the metric.",
+          "type": "integer"
+        }
+      },
+      "required": ["timestamp", "org_id", "project_id", "mri", "outcome"]
+    },
+    "U64": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 18446744073709551615
+    }
+  }
+}

--- a/schemas/outcomes-metrics.v1.schema.json
+++ b/schemas/outcomes-metrics.v1.schema.json
@@ -4,6 +4,7 @@
   "$ref": "#/definitions/MetricsOutcome",
   "definitions": {
     "MetricsOutcome": {
+      "type": "object",
       "properties": {
         "timestamp": {
           "description": "The UNIX timestamp in seconds when the outcome was created, optionally truncated to the last hour.",

--- a/schemas/outcomes-metrics.v1.schema.json
+++ b/schemas/outcomes-metrics.v1.schema.json
@@ -37,9 +37,18 @@
         "cardinality": {
           "description": "Maximum observed cardinality of the metric.",
           "$ref": "#/definitions/U64"
+        },
+        "cardinality_window": {
+          "description": "Time window, in seconds, in which the cardinality was observed.",
+          "$ref": "#/definitions/U64"
         }
       },
-      "required": ["timestamp", "org_id", "project_id", "mri", "outcome"]
+      "required": ["timestamp", "org_id", "project_id", "mri", "outcome"],
+      "dependentSchemas": {
+        "cardinality": {
+          "required": ["cardinality_window"]
+        }
+      }
     },
     "U64": {
       "type": "integer",

--- a/schemas/outcomes-metrics.v1.schema.json
+++ b/schemas/outcomes-metrics.v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "metrics-outcome",
+  "title": "metrics_outcome",
   "$ref": "#/definitions/MetricsOutcome",
   "definitions": {
     "MetricsOutcome": {

--- a/topics/outcomes-metrics.yaml
+++ b/topics/outcomes-metrics.yaml
@@ -1,0 +1,16 @@
+topic: outcomes-metrics
+pipeline: outcomes
+description: Outcomes for metrics sent to Sentry
+services:
+  producers:
+    - getsentry/relay
+  consumers:
+    - getsentry/snuba
+    - getsentry/super-big-consumers
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: json
+    resource: outcomes-metrics.v1.schema.json
+    examples:
+      -  outcomes-metrics/1

--- a/topics/outcomes-metrics.yaml
+++ b/topics/outcomes-metrics.yaml
@@ -13,4 +13,4 @@ schemas:
     type: json
     resource: outcomes-metrics.v1.schema.json
     examples:
-      -  outcomes-metrics/1
+      - outcomes-metrics/1


### PR DESCRIPTION
Preliminary schema for the `outcomes-metrics` topic, work described and tracked in https://github.com/getsentry/relay/issues/3147.

The cardinality description is vague on purpose, custom metrics will most likely have cardinality tracked per hour, but this is subject to change and may be different for other metric types (or even completely missing).