### PR TITLE
feat: Add max.message.bytes on events and transactions topics

### DIFF
--- a/topics/events.yaml
+++ b/topics/events.yaml
@@ -15,4 +15,5 @@ schemas:
     examples:
       - events/1/
 topic_creation_config:
+  max.message.bytes: "25000000"
   message.timestamp.type: LogAppendTime

--- a/topics/transactions.yaml
+++ b/topics/transactions.yaml
@@ -15,4 +15,5 @@ schemas:
     examples:
       - transactions/1/
 topic_creation_config:
+  max.message.bytes: "25000000"
   message.timestamp.type: LogAppendTime


### PR DESCRIPTION
This value seems extaordinarily large to me, but it's what we have in production today so 🤷 