### PR TITLE
fix: Fix topic creation config

### DIFF
--- a/topics/ingest-attachments-dlq.yaml
+++ b/topics/ingest-attachments-dlq.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  retention.ms: "604800000"  # 7 days
+  retention.ms: "604800000" # 7 days

--- a/topics/ingest-attachments-dlq.yaml
+++ b/topics/ingest-attachments-dlq.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  log.retention.minutes: "10080"
+  retention.ms: "604800000"  # 7 days

--- a/topics/ingest-events-dlq.yaml
+++ b/topics/ingest-events-dlq.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  retention.ms: "604800000"  # 7 days
+  retention.ms: "604800000" # 7 days

--- a/topics/ingest-events-dlq.yaml
+++ b/topics/ingest-events-dlq.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  log.retention.minutes: "10080"
+  retention.ms: "604800000"  # 7 days

--- a/topics/ingest-feedback-events-dlq.yaml
+++ b/topics/ingest-feedback-events-dlq.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  retention.ms: "604800000"  # 7 days
+  retention.ms: "604800000" # 7 days

--- a/topics/ingest-feedback-events-dlq.yaml
+++ b/topics/ingest-feedback-events-dlq.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  log.retention.minutes: "10080" # 7 days
+  retention.ms: "604800000"  # 7 days

--- a/topics/ingest-generic-metrics-dlq.yaml
+++ b/topics/ingest-generic-metrics-dlq.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  retention.ms: "604800000"  # 7 days
+  retention.ms: "604800000" # 7 days

--- a/topics/ingest-generic-metrics-dlq.yaml
+++ b/topics/ingest-generic-metrics-dlq.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  log.retention.minutes: "10080"
+  retention.ms: "604800000"  # 7 days

--- a/topics/ingest-metrics-dlq.yaml
+++ b/topics/ingest-metrics-dlq.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  retention.ms: "604800000"  # 7 days
+  retention.ms: "604800000" # 7 days

--- a/topics/ingest-metrics-dlq.yaml
+++ b/topics/ingest-metrics-dlq.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  log.retention.minutes: "10080"
+  retention.ms: "604800000"  # 7 days

--- a/topics/ingest-transactions-dlq.yaml
+++ b/topics/ingest-transactions-dlq.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  retention.ms: "604800000"  # 7 days
+  retention.ms: "604800000" # 7 days

--- a/topics/ingest-transactions-dlq.yaml
+++ b/topics/ingest-transactions-dlq.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  log.retention.minutes: "10080"
+  retention.ms: "604800000"  # 7 days

--- a/topics/snuba-dead-letter-generic-metrics.yaml
+++ b/topics/snuba-dead-letter-generic-metrics.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  retention.ms: "604800000"  # 7 days
+  retention.ms: "604800000" # 7 days

--- a/topics/snuba-dead-letter-generic-metrics.yaml
+++ b/topics/snuba-dead-letter-generic-metrics.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  log.retention.minutes: "10080"
+  retention.ms: "604800000"  # 7 days

--- a/topics/snuba-dead-letter-group-attributes.yaml
+++ b/topics/snuba-dead-letter-group-attributes.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  retention.ms: "604800000"  # 7 days
+  retention.ms: "604800000" # 7 days

--- a/topics/snuba-dead-letter-group-attributes.yaml
+++ b/topics/snuba-dead-letter-group-attributes.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  log.retention.minutes: "10080"
+  retention.ms: "604800000"  # 7 days

--- a/topics/snuba-dead-letter-metrics.yaml
+++ b/topics/snuba-dead-letter-metrics.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  retention.ms: "604800000"  # 7 days
+  retention.ms: "604800000" # 7 days

--- a/topics/snuba-dead-letter-metrics.yaml
+++ b/topics/snuba-dead-letter-metrics.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  log.retention.minutes: "10080"
+  retention.ms: "604800000"  # 7 days

--- a/topics/snuba-dead-letter-querylog.yaml
+++ b/topics/snuba-dead-letter-querylog.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  retention.ms: "604800000"  # 7 days
+  retention.ms: "604800000" # 7 days

--- a/topics/snuba-dead-letter-querylog.yaml
+++ b/topics/snuba-dead-letter-querylog.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  log.retention.minutes: "10080"
+  retention.ms: "604800000"  # 7 days

--- a/topics/snuba-dead-letter-replays.yaml
+++ b/topics/snuba-dead-letter-replays.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  retention.ms: "604800000"  # 7 days
+  retention.ms: "604800000" # 7 days

--- a/topics/snuba-dead-letter-replays.yaml
+++ b/topics/snuba-dead-letter-replays.yaml
@@ -14,4 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
-  log.retention.minutes: "10080"
+  retention.ms: "604800000"  # 7 days


### PR DESCRIPTION
should be `retention.ms` not `log.retention.minutes` which is a cluster wide setting and can't be passed for topic creation config.