### PR TITLE
feat: Add a DLQ for buffered segment topic

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,6 +30,7 @@
 
 # Topics produced by Sentry
 /topics/buffered-segments.yaml                                 @getsentry/owners-snuba @getsentry/performance
+/topics/buffered-segments-dlq.yaml                             @getsentry/owners-snuba @getsentry/performance
 
 # DLQs for Snuba topics
 /topics/snuba-dead-letter-metrics.yaml                         @getsentry/owners-snuba

--- a/topics/buffered-segments-dlq.yaml
+++ b/topics/buffered-segments-dlq.yaml
@@ -1,0 +1,15 @@
+topic: buffered-segments-dlq
+description: DLQ for buffered-segments
+services:
+  producers:
+    - getsentry/sentry
+  consumers: []
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: json
+    resource: any.json
+    examples:
+      - any/
+topic_creation_config:
+  compression.type: lz4

--- a/topics/buffered-segments-dlq.yaml
+++ b/topics/buffered-segments-dlq.yaml
@@ -13,3 +13,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "604800000" # 7 days


### PR DESCRIPTION
Adds buffered-segments-dlq
The [topic](https://github.com/getsentry/ops/blob/f451d30a5dfe06bf20aec111023f2c28a9983b18/k8s/services/topicctl/_values.yaml#L20) was already added as a part of the span only perf issue detection pipeline
Adding the schemas, adding it to the consumers