### PR TITLE
feat: Update max message size on buffered-spans

### DIFF
--- a/topics/buffered-segments.yaml
+++ b/topics/buffered-segments.yaml
@@ -14,3 +14,4 @@ schemas:
       - buffered-segments/1/
 topic_creation_config:
   compression.type: lz4
+  max.message.bytes: "10000000"


### PR DESCRIPTION
We're hitting some max message size limits while producing to this topic. We expect this payload to be around sizes we see on transactions. Not quite bumping it to 25 MB yet (that's what transactions has), want to see how far 10 MB gets us