### PR TITLE
feat: Add required partition count to topic definition

### DIFF
--- a/python/sentry_kafka_schemas/sentry_kafka_schemas.py
+++ b/python/sentry_kafka_schemas/sentry_kafka_schemas.py
@@ -51,6 +51,7 @@ class TopicData(TypedDict):
     schemas: Sequence[TopicSchema]
     pipeline: NotRequired[str]
     topic_creation_config: Mapping[str, str]
+    partitins: Optional[int]
 
 
 _TOPICS_PATH = Path.joinpath(Path(__file__).parent, "topics")
@@ -82,6 +83,9 @@ def get_topic(topic: str) -> TopicData:
         raise SchemaNotFound
     if "topic_creation_config" not in topic_data:
         topic_data["topic_creation_config"] = {}
+
+    if "partitions" not in topic_data:
+        topic_data["partitions"] = None
 
     return topic_data
 

--- a/python/tests/test_sentry_kafka_schemas.py
+++ b/python/tests/test_sentry_kafka_schemas.py
@@ -10,6 +10,10 @@ def test_get_topic() -> None:
         "max.message.bytes": "2000000",
     }
 
+    assert topic_data["partitions"] is None
+
+    assert get_topic("snuba-commit-log")["partitions"] == 1
+
 
 def test_get_schema() -> None:
     topic_name = "snuba-queries"

--- a/topics/snuba-commit-log.yaml
+++ b/topics/snuba-commit-log.yaml
@@ -18,3 +18,4 @@ topic_creation_config:
   compression.type: lz4
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
+partitions: 1  # Commit log topic must always have one partition

--- a/topics/snuba-generic-events-commit-log.yaml
+++ b/topics/snuba-generic-events-commit-log.yaml
@@ -18,3 +18,4 @@ topic_creation_config:
   compression.type: lz4
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
+partitions: 1  # Commit log topic must always have one partition

--- a/topics/snuba-generic-metrics-counters-commit-log.yaml
+++ b/topics/snuba-generic-metrics-counters-commit-log.yaml
@@ -18,3 +18,4 @@ topic_creation_config:
   compression.type: lz4
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
+partitions: 1  # Commit log topic must always have one partition

--- a/topics/snuba-generic-metrics-distributions-commit-log.yaml
+++ b/topics/snuba-generic-metrics-distributions-commit-log.yaml
@@ -18,3 +18,4 @@ topic_creation_config:
   compression.type: lz4
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
+partitions: 1  # Commit log topic must always have one partition

--- a/topics/snuba-generic-metrics-sets-commit-log.yaml
+++ b/topics/snuba-generic-metrics-sets-commit-log.yaml
@@ -18,3 +18,4 @@ topic_creation_config:
   compression.type: lz4
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
+partitions: 1  # Commit log topic must always have one partition

--- a/topics/snuba-metrics-commit-log.yaml
+++ b/topics/snuba-metrics-commit-log.yaml
@@ -18,3 +18,4 @@ topic_creation_config:
   compression.type: lz4
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
+partitions: 1  # Commit log topic must always have one partition

--- a/topics/snuba-transactions-commit-log.yaml
+++ b/topics/snuba-transactions-commit-log.yaml
@@ -18,3 +18,4 @@ topic_creation_config:
   compression.type: lz4
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
+partitions: 1  # Commit log topic must always have one partition


### PR DESCRIPTION
There are a handful of topics at sentry that require partitions=1 and will not work properly with higher counts. Specifically the commit log topics.

Currently we only define partition counts per region in ops. This PR proposes adding the count to the topic definition where it required and enforcing this in ops (which imports this repo).