### PR TITLE
Add priority to group attributes schema

### DIFF
--- a/schemas/group-attributes.v1.schema.json
+++ b/schemas/group-attributes.v1.schema.json
@@ -21,6 +21,9 @@
         "substatus": {
           "type": ["integer", "null"]
         },
+        "priority": {
+          "type": ["integer", "null"]
+        },
         "first_seen": {
           "type": "string"
         },


### PR DESCRIPTION
We're adding a new column for group_priority to the GroupAttributes table in https://github.com/getsentry/snuba/pull/5786. This updates the kafka schema to support the new field. 