### PR TITLE
feat(generic-metrics): Redo Add base64 support to metrics schemas

### DIFF
--- a/examples/ingest-metrics/1/base64-dist.json
+++ b/examples/ingest-metrics/1/base64-dist.json
@@ -1,0 +1,13 @@
+{
+  "name": "d:transactions/duration@millisecond",
+  "org_id": 1,
+  "retention_days": 90,
+  "project_id": 42,
+  "tags": {},
+  "type": "d",
+  "value": {
+    "format": "base64",
+    "data": "AAAAAAAACEAAAAAAAADwPwAAAAAAAABA"
+  },
+  "timestamp": 666666666666
+}

--- a/examples/ingest-metrics/1/base64-set.json
+++ b/examples/ingest-metrics/1/base64-set.json
@@ -1,0 +1,17 @@
+{
+  "org_id": 420,
+  "project_id": 420,
+  "name": "s:sessions/user@none",
+  "tags": {
+    "sdk": "raven-node/2.6.3",
+    "environment": "production",
+    "release": "sentry-test@1.0.0"
+  },
+  "timestamp": 11111111111,
+  "type": "s",
+  "retention_days": 90,
+  "value": {
+    "format": "base64",
+    "data": "AQAAAAcAAAA="
+  }
+}

--- a/examples/snuba-generic-metrics/1/snuba-generic-metrics-dist-base64.json
+++ b/examples/snuba-generic-metrics/1/snuba-generic-metrics-dist-base64.json
@@ -1,0 +1,32 @@
+{
+  "version": 2,
+  "use_case_id": "spans",
+  "org_id": 1,
+  "project_id": 3,
+  "metric_id": 65563,
+  "timestamp": 1704614940,
+  "sentry_received_timestamp": 1704614940,
+  "tags": {
+    "9223372036854776010": "production",
+    "9223372036854776017": "healthy",
+    "65690": "metric_e2e_spans_dist_v_VUW93LMS"
+  },
+  "retention_days": 90,
+  "mapping_meta": {
+    "d": {
+      "65560": "d:spans/duration@second"
+    },
+    "h": {
+      "9223372036854776017": "session.status",
+      "9223372036854776010": "environment"
+    },
+    "f": {
+      "65691": "metric_e2e_spans_dist_k_VUW93LMS"
+    }
+  },
+  "type": "d",
+  "value": {
+    "format": "base64",
+    "data": "AAAAAAAACEAAAAAAAADwPwAAAAAAAABA"
+  }
+}

--- a/examples/snuba-generic-metrics/1/snuba-generic-metrics-sets-base64.json
+++ b/examples/snuba-generic-metrics/1/snuba-generic-metrics-sets-base64.json
@@ -1,0 +1,32 @@
+{
+  "version": 2,
+  "use_case_id": "spans",
+  "org_id": 1,
+  "project_id": 3,
+  "metric_id": 65562,
+  "timestamp": 1704614940,
+  "sentry_received_timestamp": 1704614940,
+  "tags": {
+    "9223372036854776010": "production",
+    "9223372036854776017": "errored",
+    "65690": "metric_e2e_spans_set_v_VUW93LMS"
+  },
+  "retention_days": 90,
+  "mapping_meta": {
+    "h": {
+      "9223372036854776017": "session.status",
+      "9223372036854776010": "environment"
+    },
+    "f": {
+      "65690": "metric_e2e_spans_set_k_VUW93LMS"
+    },
+    "d": {
+      "65562": "s:spans/error@none"
+    }
+  },
+  "type": "s",
+  "value": {
+    "format": "base64",
+    "data": "AQAAAAcAAAA="
+  }
+}

--- a/schemas/ingest-metrics.v1.schema.json
+++ b/schemas/ingest-metrics.v1.schema.json
@@ -69,6 +69,19 @@
               "required": ["format", "data"]
             },
             {
+              "title": "encoded_series_base64_metric_value",
+              "type": "object",
+              "properties": {
+                "format": {
+                  "const": "base64"
+                },
+                "data": {
+                  "type": "string"
+                }
+              },
+              "required": ["format", "data"]
+            },
+            {
               "title": "counter_metric_value",
               "type": "number"
             },

--- a/schemas/snuba-generic-metrics.v1.schema.json
+++ b/schemas/snuba-generic-metrics.v1.schema.json
@@ -64,6 +64,19 @@
               "required": ["format", "data"]
             },
             {
+              "title": "encoded_series_base64_metric_value",
+              "type": "object",
+              "properties": {
+                "format": {
+                  "const": "base64"
+                },
+                "data": {
+                  "type": "string"
+                }
+              },
+              "required": ["format", "data"]
+            },
+            {
               "title": "counter_metric_value",
               "type": "number"
             },


### PR DESCRIPTION
Reverts getsentry/sentry-kafka-schemas#255