### PR TITLE
ref(crons): Allow null for sdk property

### DIFF
--- a/schemas/ingest-monitors.v1.schema.json
+++ b/schemas/ingest-monitors.v1.schema.json
@@ -48,10 +48,7 @@
         },
         "sdk": {
           "description": "The originating SDK client identifier string.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "retention_days": {
           "type": "integer",

--- a/schemas/ingest-monitors.v1.schema.json
+++ b/schemas/ingest-monitors.v1.schema.json
@@ -48,7 +48,10 @@
         },
         "sdk": {
           "description": "The originating SDK client identifier string.",
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "retention_days": {
           "type": "integer",


### PR DESCRIPTION
It seems sometimes this will not be set by relay see [0].

[0]: https://github.com/getsentry/relay/blob/4cb86c9c7f636157dd185107569cb521de40d192/relay-server/src/services/store.rs#L1531

Fixes [SENTRY-38FS](https://sentry.sentry.io/issues/5256667522/)