### PR TITLE
fix: ingest-feedback-events-dlq max.message.bytes

### DIFF
--- a/topics/ingest-feedback-events-dlq.yaml
+++ b/topics/ingest-feedback-events-dlq.yaml
@@ -14,4 +14,5 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
+  max.message.bytes: "10000000"
   retention.ms: "604800000" # 7 days


### PR DESCRIPTION
Needs to match the underlying ingest-feedback-events topic

Needs https://github.com/getsentry/sentry-kafka-schemas/pull/261