### PR TITLE
fix: Upgrade typify to unblock CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,13 +47,13 @@ thiserror = "1.0.49"
 prettyplease = { version = "0.2.4", optional = true }
 schemars = { version = "0.8.0", optional = true }
 syn = { version = "2.0.11", optional = true }
-typify = { version = "0.0.16", optional = true }
+typify = { version = "0.0.11", optional = true }
 
 [build-dependencies]
 prettyplease = { version = "0.2.4", optional = true }
 schemars = { version = "0.8.0", optional = true }
 serde_json = "1.0"
 syn = { version = "2.0.11", optional = true }
-typify = { version = "0.0.16", optional = true }
+typify = { version = "0.0.11", optional = true }
 jsonschema = "0.17.1"
 thiserror = "1.0.49"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,13 +47,13 @@ thiserror = "1.0.49"
 prettyplease = { version = "0.2.4", optional = true }
 schemars = { version = "0.8.0", optional = true }
 syn = { version = "2.0.11", optional = true }
-typify = { version = "0.0.11", optional = true }
+typify = { version = "0.0.16", optional = true }
 
 [build-dependencies]
 prettyplease = { version = "0.2.4", optional = true }
 schemars = { version = "0.8.0", optional = true }
 serde_json = "1.0"
 syn = { version = "2.0.11", optional = true }
-typify = { version = "0.0.11", optional = true }
+typify = { version = "0.0.16", optional = true }
 jsonschema = "0.17.1"
 thiserror = "1.0.49"


### PR DESCRIPTION
previous version of typify doesn't seem to work with the rust version running in github actions