### PR TITLE
feat(crons): Ensure monitor_environment_id in all clock tasks

### DIFF
--- a/examples/monitors-clock-tasks/1/mark_timeout.json
+++ b/examples/monitors-clock-tasks/1/mark_timeout.json
@@ -1,5 +1,6 @@
 {
   "type": "mark_timeout",
   "ts": 1714072962,
+  "monitor_environment_id": 1,
   "checkin_id": 1
 }

--- a/schemas/monitors-clock-tasks.v1.schema.json
+++ b/schemas/monitors-clock-tasks.v1.schema.json
@@ -33,12 +33,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "type",
-        "ts",
-        "monitor_environment_id",
-        "checkin_id"
-      ]
+      "required": ["type", "ts", "monitor_environment_id", "checkin_id"]
     },
     "MonitorsMarkMissing": {
       "type": "object",
@@ -59,11 +54,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "type",
-        "ts",
-        "monitor_environment_id"
-      ]
+      "required": ["type", "ts", "monitor_environment_id"]
     }
   }
 }

--- a/schemas/monitors-clock-tasks.v1.schema.json
+++ b/schemas/monitors-clock-tasks.v1.schema.json
@@ -24,12 +24,21 @@
           "description": "The timestamp the clock ticked at.",
           "type": "number"
         },
+        "monitor_environment_id": {
+          "description": "The monitor environment ID the check-in is part of.",
+          "type": "number"
+        },
         "checkin_id": {
           "description": "The check-in ID to mark as timedout.",
           "type": "number"
         }
       },
-      "required": ["type", "ts", "checkin_id"]
+      "required": [
+        "type",
+        "ts",
+        "monitor_environment_id",
+        "checkin_id"
+      ]
     },
     "MonitorsMarkMissing": {
       "type": "object",
@@ -50,7 +59,11 @@
           "type": "number"
         }
       },
-      "required": ["type", "ts", "monitor_environment_id"]
+      "required": [
+        "type",
+        "ts",
+        "monitor_environment_id"
+      ]
     }
   }
 }


### PR DESCRIPTION
We're going to use this to group tasks in the task consumer, so we need
it to be part of all messages