### PR TITLE
feat(generic-metrics): Switch Kafka schema examples to non-padded Base64 encoding

### DIFF
--- a/examples/ingest-metrics/1/base64-set.json
+++ b/examples/ingest-metrics/1/base64-set.json
@@ -12,6 +12,6 @@
   "retention_days": 90,
   "value": {
     "format": "base64",
-    "data": "AQAAAAcAAAA="
+    "data": "AQAAAAcAAAA"
   }
 }

--- a/examples/snuba-generic-metrics/1/snuba-generic-metrics-sets-base64.json
+++ b/examples/snuba-generic-metrics/1/snuba-generic-metrics-sets-base64.json
@@ -27,6 +27,6 @@
   "type": "s",
   "value": {
     "format": "base64",
-    "data": "AQAAAAcAAAA="
+    "data": "AQAAAAcAAAA"
   }
 }


### PR DESCRIPTION
Since we're moving to using the non-padded version, we need to adjust the Kafka schema examples accordingly to generate snapshots in Snuba. 

The Rust consumers are evaluated against these examples in the Snuba test suite. 