### PR TITLE
feat: Add missing event-replacements topic

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -86,6 +86,7 @@
 
 # Internal Snuba topics
 /topics/snuba-queries.yaml                                     @getsentry/owners-snuba
+/topics/event-replacements.yaml                                @getsentry/owners-snuba
 
 # Scheduled subscription topics
 /topics/scheduled-subscriptions-events.yaml                         @getsentry/owners-snuba

--- a/topics/event-replacements.yaml
+++ b/topics/event-replacements.yaml
@@ -14,3 +14,4 @@ schemas:
       - any/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/event-replacements.yaml
+++ b/topics/event-replacements.yaml
@@ -1,0 +1,16 @@
+topic: event-replacements
+description: Error replacements
+services:
+  producers:
+    - getsentry/snuba
+  consumers:
+    - getsentry/snuba
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: json
+    resource: any.json
+    examples:
+      - any/
+topic_creation_config:
+  compression.type: lz4


### PR DESCRIPTION
Needs to be here for kafka control plane, as these will be used to generate production configs in ops.
Ideally this would have a more defined schema + examples.