### PR TITLE
Make retention.ms a mandatory field

### DIFF
--- a/python/tests/test_sentry_kafka_schemas.py
+++ b/python/tests/test_sentry_kafka_schemas.py
@@ -8,6 +8,7 @@ def test_get_topic() -> None:
     assert topic_data["topic_creation_config"] == {
         "compression.type": "lz4",
         "max.message.bytes": "2000000",
+        "retention.ms": "86400000",
     }
 
     assert topic_data["partitions"] is None

--- a/python/tests/test_valid_topic_data.py
+++ b/python/tests/test_valid_topic_data.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from sentry_kafka_schemas import get_codec
+from sentry_kafka_schemas import get_codec, list_topics, get_topic
 import fastjsonschema
 from yaml import safe_load
 import re
@@ -137,3 +137,12 @@ def test_all_topics() -> None:
     # Assert that every example file in examples/ is referenced by a topic.
     unused_examples = existing_examples - used_examples
     assert not unused_examples
+
+
+def test_retention() -> None:
+    # All topics at sentry have either 1 day or 7 day retention and this property is mandatory
+    allowed_values = (str(1 * 1000 * 60 * 60 * 24), str(7 * 1000 * 60 * 60 * 24))
+
+    for topic_name in list_topics():
+        topic = get_topic(topic_name)
+        assert topic["topic_creation_config"]["retention.ms"] in allowed_values

--- a/topics/buffered-segments.yaml
+++ b/topics/buffered-segments.yaml
@@ -14,3 +14,4 @@ schemas:
       - buffered-segments/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/events-subscription-results.yaml
+++ b/topics/events-subscription-results.yaml
@@ -15,3 +15,4 @@ schemas:
       - subscription-results/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/events.yaml
+++ b/topics/events.yaml
@@ -18,3 +18,4 @@ topic_creation_config:
   compression.type: lz4
   max.message.bytes: "25000000"
   message.timestamp.type: LogAppendTime
+  retention.ms: "86400000"

--- a/topics/generic-events.yaml
+++ b/topics/generic-events.yaml
@@ -16,3 +16,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   message.timestamp.type: LogAppendTime
+  retention.ms: "86400000"

--- a/topics/generic-metrics-subscription-results.yaml
+++ b/topics/generic-metrics-subscription-results.yaml
@@ -15,3 +15,4 @@ schemas:
       - subscription-results/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/group-attributes.yaml
+++ b/topics/group-attributes.yaml
@@ -15,3 +15,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   message.timestamp.type: LogAppendTime
+  retention.ms: "86400000"

--- a/topics/ingest-events.yaml
+++ b/topics/ingest-events.yaml
@@ -16,3 +16,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   max.message.bytes: "10000000"
+  retention.ms: "86400000"

--- a/topics/ingest-feedback-events.yaml
+++ b/topics/ingest-feedback-events.yaml
@@ -16,3 +16,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   max.message.bytes: "10000000"
+  retention.ms: "86400000"

--- a/topics/ingest-metrics.yaml
+++ b/topics/ingest-metrics.yaml
@@ -16,3 +16,4 @@ schemas:
       - ingest-metrics/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/ingest-monitors.yaml
+++ b/topics/ingest-monitors.yaml
@@ -18,3 +18,4 @@ topic_creation_config:
   max.message.bytes: "10000000"
   message.timestamp.type: LogAppendTime
   segment.bytes: "1073741824"
+  retention.ms: "86400000"

--- a/topics/ingest-performance-metrics.yaml
+++ b/topics/ingest-performance-metrics.yaml
@@ -15,3 +15,4 @@ schemas:
       - ingest-metrics/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/ingest-replay-events.yaml
+++ b/topics/ingest-replay-events.yaml
@@ -18,3 +18,4 @@ topic_creation_config:
   compression.type: lz4
   message.timestamp.type: LogAppendTime
   max.message.bytes: "15000000"
+  retention.ms: "86400000"

--- a/topics/ingest-replay-recordings.yaml
+++ b/topics/ingest-replay-recordings.yaml
@@ -15,3 +15,4 @@ schemas:
       - ingest-replay-recordings/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/metrics-subscription-results.yaml
+++ b/topics/metrics-subscription-results.yaml
@@ -15,3 +15,4 @@ schemas:
       - subscription-results/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/monitors-clock-tasks.yaml
+++ b/topics/monitors-clock-tasks.yaml
@@ -16,3 +16,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   message.timestamp.type: LogAppendTime
+  retention.ms: "86400000"

--- a/topics/monitors-clock-tick.yaml
+++ b/topics/monitors-clock-tick.yaml
@@ -16,3 +16,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   message.timestamp.type: LogAppendTime
+  retention.ms: "86400000"

--- a/topics/outcomes-billing.yaml
+++ b/topics/outcomes-billing.yaml
@@ -18,3 +18,4 @@ schemas:
       - outcomes/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/outcomes.yaml
+++ b/topics/outcomes.yaml
@@ -18,3 +18,4 @@ schemas:
       - outcomes/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/processed-profiles.yaml
+++ b/topics/processed-profiles.yaml
@@ -16,3 +16,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   message.timestamp.type: LogAppendTime
+  retention.ms: "86400000"

--- a/topics/profiles-call-tree.yaml
+++ b/topics/profiles-call-tree.yaml
@@ -16,3 +16,4 @@ schemas:
       - profile-functions/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/scheduled-subscriptions-events.yaml
+++ b/topics/scheduled-subscriptions-events.yaml
@@ -15,3 +15,4 @@ schemas:
       - subscription-scheduled/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/scheduled-subscriptions-generic-metrics-counters.yaml
+++ b/topics/scheduled-subscriptions-generic-metrics-counters.yaml
@@ -15,3 +15,4 @@ schemas:
       - subscription-scheduled/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/scheduled-subscriptions-generic-metrics-distributions.yaml
+++ b/topics/scheduled-subscriptions-generic-metrics-distributions.yaml
@@ -15,3 +15,4 @@ schemas:
       - subscription-scheduled/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/scheduled-subscriptions-generic-metrics-gauges.yaml
+++ b/topics/scheduled-subscriptions-generic-metrics-gauges.yaml
@@ -15,3 +15,4 @@ schemas:
       - subscription-scheduled/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/scheduled-subscriptions-generic-metrics-sets.yaml
+++ b/topics/scheduled-subscriptions-generic-metrics-sets.yaml
@@ -15,3 +15,4 @@ schemas:
       - subscription-scheduled/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/scheduled-subscriptions-metrics.yaml
+++ b/topics/scheduled-subscriptions-metrics.yaml
@@ -15,3 +15,4 @@ schemas:
       - subscription-scheduled/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/scheduled-subscriptions-transactions.yaml
+++ b/topics/scheduled-subscriptions-transactions.yaml
@@ -15,3 +15,4 @@ schemas:
       - subscription-scheduled/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/shared-resources-usage.yaml
+++ b/topics/shared-resources-usage.yaml
@@ -14,3 +14,4 @@ schemas:
       - shared-resources-usage/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/snuba-commit-log.yaml
+++ b/topics/snuba-commit-log.yaml
@@ -18,4 +18,5 @@ topic_creation_config:
   compression.type: lz4
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
+  retention.ms: "86400000"
 partitions: 1 # Commit log topic must always have one partition

--- a/topics/snuba-generic-events-commit-log.yaml
+++ b/topics/snuba-generic-events-commit-log.yaml
@@ -18,4 +18,5 @@ topic_creation_config:
   compression.type: lz4
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
+  retention.ms: "86400000"
 partitions: 1 # Commit log topic must always have one partition

--- a/topics/snuba-generic-metrics-counters-commit-log.yaml
+++ b/topics/snuba-generic-metrics-counters-commit-log.yaml
@@ -18,4 +18,5 @@ topic_creation_config:
   compression.type: lz4
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
+  retention.ms: "86400000"
 partitions: 1 # Commit log topic must always have one partition

--- a/topics/snuba-generic-metrics-distributions-commit-log.yaml
+++ b/topics/snuba-generic-metrics-distributions-commit-log.yaml
@@ -18,4 +18,5 @@ topic_creation_config:
   compression.type: lz4
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
+  retention.ms: "86400000"
 partitions: 1 # Commit log topic must always have one partition

--- a/topics/snuba-generic-metrics-gauges-commit-log.yaml
+++ b/topics/snuba-generic-metrics-gauges-commit-log.yaml
@@ -18,3 +18,4 @@ topic_creation_config:
   compression.type: lz4
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
+  retention.ms: "86400000"

--- a/topics/snuba-generic-metrics-sets-commit-log.yaml
+++ b/topics/snuba-generic-metrics-sets-commit-log.yaml
@@ -18,4 +18,5 @@ topic_creation_config:
   compression.type: lz4
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
+  retention.ms: "86400000"
 partitions: 1 # Commit log topic must always have one partition

--- a/topics/snuba-generic-metrics.yaml
+++ b/topics/snuba-generic-metrics.yaml
@@ -16,3 +16,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   message.timestamp.type: LogAppendTime
+  retention.ms: "86400000"

--- a/topics/snuba-metrics-commit-log.yaml
+++ b/topics/snuba-metrics-commit-log.yaml
@@ -18,4 +18,5 @@ topic_creation_config:
   compression.type: lz4
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
+  retention.ms: "86400000"
 partitions: 1 # Commit log topic must always have one partition

--- a/topics/snuba-metrics-summaries.yaml
+++ b/topics/snuba-metrics-summaries.yaml
@@ -14,3 +14,4 @@ schemas:
       - snuba-metrics-summaries/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/snuba-metrics.yaml
+++ b/topics/snuba-metrics.yaml
@@ -16,3 +16,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   message.timestamp.type: LogAppendTime
+  retention.ms: "86400000"

--- a/topics/snuba-queries.yaml
+++ b/topics/snuba-queries.yaml
@@ -15,3 +15,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   max.message.bytes: "2000000"
+  retention.ms: "86400000"

--- a/topics/snuba-spans.yaml
+++ b/topics/snuba-spans.yaml
@@ -15,3 +15,4 @@ schemas:
       - snuba-spans/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/snuba-transactions-commit-log.yaml
+++ b/topics/snuba-transactions-commit-log.yaml
@@ -18,4 +18,5 @@ topic_creation_config:
   compression.type: lz4
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
+  retention.ms: "86400000"
 partitions: 1 # Commit log topic must always have one partition

--- a/topics/transactions-subscription-results.yaml
+++ b/topics/transactions-subscription-results.yaml
@@ -15,3 +15,4 @@ schemas:
       - subscription-results/1/
 topic_creation_config:
   compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/transactions.yaml
+++ b/topics/transactions.yaml
@@ -18,3 +18,4 @@ topic_creation_config:
   compression.type: lz4
   max.message.bytes: "25000000"
   message.timestamp.type: LogAppendTime
+  retention.ms: "86400000"


### PR DESCRIPTION
All topics must specify retention, which should be 1 or 7 days. At sentry we use 1 day for all topics except DLQs which have 7.