### PR TITLE
feat(generic-metrics): Add support for zstd compression in message processing

### DIFF
--- a/examples/ingest-metrics/1/zstd-dist.json
+++ b/examples/ingest-metrics/1/zstd-dist.json
@@ -1,0 +1,13 @@
+{
+    "name": "d:transactions/duration@millisecond",
+    "org_id": 1,
+    "retention_days": 90,
+    "project_id": 42,
+    "tags": {},
+    "type": "d",
+    "value": {
+        "format": "zstd",
+        "data": "KLUv/QBYrQAAcAAA8D8AQAAAAAAAAAhAAgBgRgCw"
+    },
+    "timestamp": 666666666666
+}

--- a/examples/ingest-metrics/1/zstd-dist.json
+++ b/examples/ingest-metrics/1/zstd-dist.json
@@ -1,13 +1,13 @@
 {
-    "name": "d:transactions/duration@millisecond",
-    "org_id": 1,
-    "retention_days": 90,
-    "project_id": 42,
-    "tags": {},
-    "type": "d",
-    "value": {
-        "format": "zstd",
-        "data": "KLUv/QBYrQAAcAAA8D8AQAAAAAAAAAhAAgBgRgCw"
-    },
-    "timestamp": 666666666666
+  "name": "d:transactions/duration@millisecond",
+  "org_id": 1,
+  "retention_days": 90,
+  "project_id": 42,
+  "tags": {},
+  "type": "d",
+  "value": {
+    "format": "zstd",
+    "data": "KLUv/QBYrQAAcAAA8D8AQAAAAAAAAAhAAgBgRgCw"
+  },
+  "timestamp": 666666666666
 }

--- a/examples/ingest-metrics/1/zstd-set.json
+++ b/examples/ingest-metrics/1/zstd-set.json
@@ -1,0 +1,17 @@
+{
+    "org_id": 420,
+    "project_id": 420,
+    "name": "s:sessions/user@none",
+    "tags": {
+        "sdk": "raven-node/2.6.3",
+        "environment": "production",
+        "release": "sentry-test@1.0.0"
+    },
+    "timestamp": 11111111111,
+    "type": "s",
+    "retention_days": 90,
+    "value": {
+        "format": "base64",
+        "data": "KLUv/QBYQQAAAQAAAAcAAAA"
+    }
+}

--- a/examples/ingest-metrics/1/zstd-set.json
+++ b/examples/ingest-metrics/1/zstd-set.json
@@ -1,17 +1,17 @@
 {
-    "org_id": 420,
-    "project_id": 420,
-    "name": "s:sessions/user@none",
-    "tags": {
-        "sdk": "raven-node/2.6.3",
-        "environment": "production",
-        "release": "sentry-test@1.0.0"
-    },
-    "timestamp": 11111111111,
-    "type": "s",
-    "retention_days": 90,
-    "value": {
-        "format": "base64",
-        "data": "KLUv/QBYQQAAAQAAAAcAAAA"
-    }
+  "org_id": 420,
+  "project_id": 420,
+  "name": "s:sessions/user@none",
+  "tags": {
+    "sdk": "raven-node/2.6.3",
+    "environment": "production",
+    "release": "sentry-test@1.0.0"
+  },
+  "timestamp": 11111111111,
+  "type": "s",
+  "retention_days": 90,
+  "value": {
+    "format": "base64",
+    "data": "KLUv/QBYQQAAAQAAAAcAAAA"
+  }
 }

--- a/examples/ingest-metrics/1/zstd-set.json
+++ b/examples/ingest-metrics/1/zstd-set.json
@@ -1,17 +1,17 @@
 {
-  "org_id": 420,
-  "project_id": 420,
-  "name": "s:sessions/user@none",
-  "tags": {
-    "sdk": "raven-node/2.6.3",
-    "environment": "production",
-    "release": "sentry-test@1.0.0"
-  },
-  "timestamp": 11111111111,
-  "type": "s",
-  "retention_days": 90,
-  "value": {
-    "format": "base64",
-    "data": "KLUv/QBYQQAAAQAAAAcAAAA"
-  }
+    "org_id": 420,
+    "project_id": 420,
+    "name": "s:sessions/user@none",
+    "tags": {
+        "sdk": "raven-node/2.6.3",
+        "environment": "production",
+        "release": "sentry-test@1.0.0"
+    },
+    "timestamp": 11111111111,
+    "type": "s",
+    "retention_days": 90,
+    "value": {
+        "format": "zstd",
+        "data": "KLUv/QBYQQAAAQAAAAcAAAA"
+    }
 }

--- a/examples/ingest-metrics/1/zstd-set.json
+++ b/examples/ingest-metrics/1/zstd-set.json
@@ -1,17 +1,17 @@
 {
-    "org_id": 420,
-    "project_id": 420,
-    "name": "s:sessions/user@none",
-    "tags": {
-        "sdk": "raven-node/2.6.3",
-        "environment": "production",
-        "release": "sentry-test@1.0.0"
-    },
-    "timestamp": 11111111111,
-    "type": "s",
-    "retention_days": 90,
-    "value": {
-        "format": "zstd",
-        "data": "KLUv/QBYQQAAAQAAAAcAAAA"
-    }
+  "org_id": 420,
+  "project_id": 420,
+  "name": "s:sessions/user@none",
+  "tags": {
+    "sdk": "raven-node/2.6.3",
+    "environment": "production",
+    "release": "sentry-test@1.0.0"
+  },
+  "timestamp": 11111111111,
+  "type": "s",
+  "retention_days": 90,
+  "value": {
+    "format": "zstd",
+    "data": "KLUv/QBYQQAAAQAAAAcAAAA"
+  }
 }

--- a/examples/snuba-generic-metrics/1/snuba-generic-metrics-dist-zstd.json
+++ b/examples/snuba-generic-metrics/1/snuba-generic-metrics-dist-zstd.json
@@ -1,0 +1,32 @@
+{
+    "version": 2,
+    "use_case_id": "spans",
+    "org_id": 1,
+    "project_id": 3,
+    "metric_id": 65563,
+    "timestamp": 1704614940,
+    "sentry_received_timestamp": 1704614940,
+    "tags": {
+        "9223372036854776010": "production",
+        "9223372036854776017": "healthy",
+        "65690": "metric_e2e_spans_dist_v_VUW93LMS"
+    },
+    "retention_days": 90,
+    "mapping_meta": {
+        "d": {
+            "65560": "d:spans/duration@second"
+        },
+        "h": {
+            "9223372036854776017": "session.status",
+            "9223372036854776010": "environment"
+        },
+        "f": {
+            "65691": "metric_e2e_spans_dist_k_VUW93LMS"
+        }
+    },
+    "type": "d",
+    "value": {
+        "format": "zstd",
+        "data": "KLUv/QBYrQAAcAAA8D8AQAAAAAAAAAhAAgBgRgCw"
+    }
+}

--- a/examples/snuba-generic-metrics/1/snuba-generic-metrics-dist-zstd.json
+++ b/examples/snuba-generic-metrics/1/snuba-generic-metrics-dist-zstd.json
@@ -1,32 +1,32 @@
 {
-    "version": 2,
-    "use_case_id": "spans",
-    "org_id": 1,
-    "project_id": 3,
-    "metric_id": 65563,
-    "timestamp": 1704614940,
-    "sentry_received_timestamp": 1704614940,
-    "tags": {
-        "9223372036854776010": "production",
-        "9223372036854776017": "healthy",
-        "65690": "metric_e2e_spans_dist_v_VUW93LMS"
+  "version": 2,
+  "use_case_id": "spans",
+  "org_id": 1,
+  "project_id": 3,
+  "metric_id": 65563,
+  "timestamp": 1704614940,
+  "sentry_received_timestamp": 1704614940,
+  "tags": {
+    "9223372036854776010": "production",
+    "9223372036854776017": "healthy",
+    "65690": "metric_e2e_spans_dist_v_VUW93LMS"
+  },
+  "retention_days": 90,
+  "mapping_meta": {
+    "d": {
+      "65560": "d:spans/duration@second"
     },
-    "retention_days": 90,
-    "mapping_meta": {
-        "d": {
-            "65560": "d:spans/duration@second"
-        },
-        "h": {
-            "9223372036854776017": "session.status",
-            "9223372036854776010": "environment"
-        },
-        "f": {
-            "65691": "metric_e2e_spans_dist_k_VUW93LMS"
-        }
+    "h": {
+      "9223372036854776017": "session.status",
+      "9223372036854776010": "environment"
     },
-    "type": "d",
-    "value": {
-        "format": "zstd",
-        "data": "KLUv/QBYrQAAcAAA8D8AQAAAAAAAAAhAAgBgRgCw"
+    "f": {
+      "65691": "metric_e2e_spans_dist_k_VUW93LMS"
     }
+  },
+  "type": "d",
+  "value": {
+    "format": "zstd",
+    "data": "KLUv/QBYrQAAcAAA8D8AQAAAAAAAAAhAAgBgRgCw"
+  }
 }

--- a/examples/snuba-generic-metrics/1/snuba-generic-metrics-sets-zstd.json
+++ b/examples/snuba-generic-metrics/1/snuba-generic-metrics-sets-zstd.json
@@ -1,0 +1,32 @@
+{
+    "version": 2,
+    "use_case_id": "spans",
+    "org_id": 1,
+    "project_id": 3,
+    "metric_id": 65562,
+    "timestamp": 1704614940,
+    "sentry_received_timestamp": 1704614940,
+    "tags": {
+        "9223372036854776010": "production",
+        "9223372036854776017": "errored",
+        "65690": "metric_e2e_spans_set_v_VUW93LMS"
+    },
+    "retention_days": 90,
+    "mapping_meta": {
+        "h": {
+            "9223372036854776017": "session.status",
+            "9223372036854776010": "environment"
+        },
+        "f": {
+            "65690": "metric_e2e_spans_set_k_VUW93LMS"
+        },
+        "d": {
+            "65562": "s:spans/error@none"
+        }
+    },
+    "type": "s",
+    "value": {
+        "format": "zstd",
+        "data": "KLUv/QBYQQAAAQAAAAcAAAA"
+    }
+}

--- a/examples/snuba-generic-metrics/1/snuba-generic-metrics-sets-zstd.json
+++ b/examples/snuba-generic-metrics/1/snuba-generic-metrics-sets-zstd.json
@@ -1,32 +1,32 @@
 {
-    "version": 2,
-    "use_case_id": "spans",
-    "org_id": 1,
-    "project_id": 3,
-    "metric_id": 65562,
-    "timestamp": 1704614940,
-    "sentry_received_timestamp": 1704614940,
-    "tags": {
-        "9223372036854776010": "production",
-        "9223372036854776017": "errored",
-        "65690": "metric_e2e_spans_set_v_VUW93LMS"
+  "version": 2,
+  "use_case_id": "spans",
+  "org_id": 1,
+  "project_id": 3,
+  "metric_id": 65562,
+  "timestamp": 1704614940,
+  "sentry_received_timestamp": 1704614940,
+  "tags": {
+    "9223372036854776010": "production",
+    "9223372036854776017": "errored",
+    "65690": "metric_e2e_spans_set_v_VUW93LMS"
+  },
+  "retention_days": 90,
+  "mapping_meta": {
+    "h": {
+      "9223372036854776017": "session.status",
+      "9223372036854776010": "environment"
     },
-    "retention_days": 90,
-    "mapping_meta": {
-        "h": {
-            "9223372036854776017": "session.status",
-            "9223372036854776010": "environment"
-        },
-        "f": {
-            "65690": "metric_e2e_spans_set_k_VUW93LMS"
-        },
-        "d": {
-            "65562": "s:spans/error@none"
-        }
+    "f": {
+      "65690": "metric_e2e_spans_set_k_VUW93LMS"
     },
-    "type": "s",
-    "value": {
-        "format": "zstd",
-        "data": "KLUv/QBYQQAAAQAAAAcAAAA"
+    "d": {
+      "65562": "s:spans/error@none"
     }
+  },
+  "type": "s",
+  "value": {
+    "format": "zstd",
+    "data": "KLUv/QBYQQAAAQAAAAcAAAA"
+  }
 }

--- a/schemas/ingest-metrics.v1.schema.json
+++ b/schemas/ingest-metrics.v1.schema.json
@@ -26,7 +26,12 @@
         "type": {
           "description": "The metric type. [c]ounter, [d]istribution, [s]et. Relay additionally defines Gauge, but that metric type is completely unsupported downstream.",
           "type": "string",
-          "enum": ["c", "d", "s", "g"]
+          "enum": [
+            "c",
+            "d",
+            "s",
+            "g"
+          ]
         },
         "timestamp": {
           "description": "The timestamp at which this metric was being sent. Relay will round this down to the next 10-second interval.",
@@ -66,7 +71,10 @@
                   ]
                 }
               },
-              "required": ["format", "data"]
+              "required": [
+                "format",
+                "data"
+              ]
             },
             {
               "title": "encoded_series_base64_metric_value",
@@ -79,7 +87,26 @@
                   "type": "string"
                 }
               },
-              "required": ["format", "data"]
+              "required": [
+                "format",
+                "data"
+              ]
+            },
+            {
+              "title": "encoded_series_zstd_metric_value",
+              "type": "object",
+              "properties": {
+                "format": {
+                  "const": "zstd"
+                },
+                "data": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "format",
+                "data"
+              ]
             },
             {
               "title": "counter_metric_value",
@@ -122,7 +149,13 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["min", "max", "sum", "count", "last"]
+              "required": [
+                "min",
+                "max",
+                "sum",
+                "count",
+                "last"
+              ]
             }
           ]
         },

--- a/schemas/ingest-metrics.v1.schema.json
+++ b/schemas/ingest-metrics.v1.schema.json
@@ -26,12 +26,7 @@
         "type": {
           "description": "The metric type. [c]ounter, [d]istribution, [s]et. Relay additionally defines Gauge, but that metric type is completely unsupported downstream.",
           "type": "string",
-          "enum": [
-            "c",
-            "d",
-            "s",
-            "g"
-          ]
+          "enum": ["c", "d", "s", "g"]
         },
         "timestamp": {
           "description": "The timestamp at which this metric was being sent. Relay will round this down to the next 10-second interval.",
@@ -71,10 +66,7 @@
                   ]
                 }
               },
-              "required": [
-                "format",
-                "data"
-              ]
+              "required": ["format", "data"]
             },
             {
               "title": "encoded_series_base64_metric_value",
@@ -87,10 +79,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "format",
-                "data"
-              ]
+              "required": ["format", "data"]
             },
             {
               "title": "encoded_series_zstd_metric_value",
@@ -103,10 +92,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "format",
-                "data"
-              ]
+              "required": ["format", "data"]
             },
             {
               "title": "counter_metric_value",
@@ -149,13 +135,7 @@
                 }
               },
               "additionalProperties": false,
-              "required": [
-                "min",
-                "max",
-                "sum",
-                "count",
-                "last"
-              ]
+              "required": ["min", "max", "sum", "count", "last"]
             }
           ]
         },

--- a/schemas/snuba-generic-metrics.v1.schema.json
+++ b/schemas/snuba-generic-metrics.v1.schema.json
@@ -61,7 +61,10 @@
                   ]
                 }
               },
-              "required": ["format", "data"]
+              "required": [
+                "format",
+                "data"
+              ]
             },
             {
               "title": "encoded_series_base64_metric_value",
@@ -74,7 +77,26 @@
                   "type": "string"
                 }
               },
-              "required": ["format", "data"]
+              "required": [
+                "format",
+                "data"
+              ]
+            },
+            {
+              "title": "encoded_series_zstd_metric_value",
+              "type": "object",
+              "properties": {
+                "format": {
+                  "const": "zstd"
+                },
+                "data": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "format",
+                "data"
+              ]
             },
             {
               "title": "counter_metric_value",
@@ -115,7 +137,13 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["min", "max", "sum", "count", "last"]
+              "required": [
+                "min",
+                "max",
+                "sum",
+                "count",
+                "last"
+              ]
             }
           ]
         },

--- a/schemas/snuba-generic-metrics.v1.schema.json
+++ b/schemas/snuba-generic-metrics.v1.schema.json
@@ -61,10 +61,7 @@
                   ]
                 }
               },
-              "required": [
-                "format",
-                "data"
-              ]
+              "required": ["format", "data"]
             },
             {
               "title": "encoded_series_base64_metric_value",
@@ -77,10 +74,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "format",
-                "data"
-              ]
+              "required": ["format", "data"]
             },
             {
               "title": "encoded_series_zstd_metric_value",
@@ -93,10 +87,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "format",
-                "data"
-              ]
+              "required": ["format", "data"]
             },
             {
               "title": "counter_metric_value",
@@ -137,13 +128,7 @@
                 }
               },
               "additionalProperties": false,
-              "required": [
-                "min",
-                "max",
-                "sum",
-                "count",
-                "last"
-              ]
+              "required": ["min", "max", "sum", "count", "last"]
             }
           ]
         },


### PR DESCRIPTION
The last (and possibly most important) step of bucket encoding and compression. Adding actual compression support to the schema. 