### PR TITLE
feat(metrics): Add received_at timestamp to Kafka schema

### DIFF
--- a/schemas/ingest-metrics.v1.schema.json
+++ b/schemas/ingest-metrics.v1.schema.json
@@ -130,6 +130,12 @@
           "type": "integer",
           "minimum": 0,
           "maximum": 65535
+        },
+        "received_at": {
+          "description": "The oldest timestamp of the first metric that was received in this bucket by the outermost internal Relay.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
         }
       },
       "required": [


### PR DESCRIPTION
This PR adds the `received_at` field to the Kafka schema for metrics produced by Relay.

Related to: https://github.com/getsentry/relay/pull/3561