### PR TITLE
fix: max.message.bytes for dlq topics

### DIFF
--- a/topics/ingest-events-dlq.yaml
+++ b/topics/ingest-events-dlq.yaml
@@ -15,3 +15,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   retention.ms: "604800000" # 7 days
+  max.message.bytes: "10000000"

--- a/topics/ingest-transactions-dlq.yaml
+++ b/topics/ingest-transactions-dlq.yaml
@@ -15,3 +15,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   retention.ms: "604800000" # 7 days
+  max.message.bytes: "10000000"


### PR DESCRIPTION
this should match message size on the underlying topics they are dlq for