### PR TITLE
set max message bytes on snuba-metrics and snuba-dead-letter-metrics to 10mb

### DIFF
--- a/topics/snuba-dead-letter-metrics.yaml
+++ b/topics/snuba-dead-letter-metrics.yaml
@@ -15,3 +15,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   retention.ms: "604800000" # 7 days
+  max.message.bytes: "10000000"

--- a/topics/snuba-metrics.yaml
+++ b/topics/snuba-metrics.yaml
@@ -16,4 +16,5 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   message.timestamp.type: LogAppendTime
+  max.message.bytes: "10000000"
   retention.ms: "86400000"


### PR DESCRIPTION
this reflects what we have in production, all definitions should align