### PR TITLE
fix: Move default rule to the top of the file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,7 @@
+# Search and storage and infra is the default owner
+#
+* @getsentry/owners-snuba @getsentry/ops
+
 # Ingest topics
 /topics/ingest-events.yaml                                     @getsentry/owners-snuba @getsentry/ingest @getsentry/ops
 /topics/ingest-metrics.yaml                                    @getsentry/owners-snuba @getsentry/ingest
@@ -107,6 +111,3 @@
 /topics/generic-metrics-subscription-results.yaml                   @getsentry/owners-snuba @getsentry/issues
 /schemas/subscription-result.v1.schema.json                         @getsentry/owners-snuba @getsentry/issues
 /examples/subscription-results/                                     @getsentry/owners-snuba @getsentry/issues
-
-# Search and storage and infra is the default owner
-* @getsentry/owners-snuba @getsentry/ops

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,4 @@
 # Search and storage and infra is the default owner
-#
 * @getsentry/owners-snuba @getsentry/ops
 
 # Ingest topics


### PR DESCRIPTION
According to https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
```
If the code owners are not on the same line, the pattern matches only the last mentioned code owner.
```
So, in order to have specific owners for specific files, the broader rules need to the at the top.