### PR TITLE
fix(spans): Fix timestamp names to reflect better their use

### DIFF
--- a/schemas/snuba-spans.v1.schema.json
+++ b/schemas/snuba-spans.v1.schema.json
@@ -45,13 +45,13 @@
           "$ref": "#/definitions/UInt",
           "description": "The start timestamp of the span in milliseconds since epoch."
         },
-        "start_timestamp_micro": {
+        "start_timestamp_precise": {
           "$ref": "#/definitions/PositiveFloat",
-          "description": "UNIX timestamp in seconds with microsecond precision."
+          "description": "UNIX timestamp in seconds with fractional part up to microsecond precision."
         },
-        "end_timestamp_micro": {
+        "end_timestamp_precise": {
           "$ref": "#/definitions/PositiveFloat",
-          "description": "UNIX timestamp in seconds with microsecond precision."
+          "description": "UNIX timestamp in seconds with fractional part up to microsecond precision."
         },
         "duration_ms": {
           "$ref": "#/definitions/UInt32",


### PR DESCRIPTION
I also retracted the previous release introducing the fields.

https://github.com/getsentry/publish/issues/3862#issuecomment-2115517847