### PR TITLE
introduce standard segment settings for all commit log topics

### DIFF
--- a/topics/snuba-commit-log.yaml
+++ b/topics/snuba-commit-log.yaml
@@ -19,4 +19,6 @@ topic_creation_config:
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
   retention.ms: "86400000"
+  segment.bytes: "104857600"
+  segment.ms: "3600000"
 partitions: 1 # Commit log topic must always have one partition

--- a/topics/snuba-generic-events-commit-log.yaml
+++ b/topics/snuba-generic-events-commit-log.yaml
@@ -19,4 +19,6 @@ topic_creation_config:
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
   retention.ms: "86400000"
+  segment.bytes: "104857600"
+  segment.ms: "3600000"
 partitions: 1 # Commit log topic must always have one partition

--- a/topics/snuba-generic-metrics-counters-commit-log.yaml
+++ b/topics/snuba-generic-metrics-counters-commit-log.yaml
@@ -19,4 +19,6 @@ topic_creation_config:
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
   retention.ms: "86400000"
+  segment.bytes: "104857600"
+  segment.ms: "3600000"
 partitions: 1 # Commit log topic must always have one partition

--- a/topics/snuba-generic-metrics-distributions-commit-log.yaml
+++ b/topics/snuba-generic-metrics-distributions-commit-log.yaml
@@ -19,4 +19,6 @@ topic_creation_config:
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
   retention.ms: "86400000"
+  segment.bytes: "104857600"
+  segment.ms: "3600000"
 partitions: 1 # Commit log topic must always have one partition

--- a/topics/snuba-generic-metrics-gauges-commit-log.yaml
+++ b/topics/snuba-generic-metrics-gauges-commit-log.yaml
@@ -19,3 +19,6 @@ topic_creation_config:
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
   retention.ms: "86400000"
+  segment.bytes: "104857600"
+  segment.ms: "3600000"
+partitions: 1 # Commit log topic must always have one partition

--- a/topics/snuba-generic-metrics-sets-commit-log.yaml
+++ b/topics/snuba-generic-metrics-sets-commit-log.yaml
@@ -19,4 +19,7 @@ topic_creation_config:
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
   retention.ms: "86400000"
+  retention.ms: "86400000"
+  segment.bytes: "104857600"
+  segment.ms: "3600000"
 partitions: 1 # Commit log topic must always have one partition

--- a/topics/snuba-metrics-commit-log.yaml
+++ b/topics/snuba-metrics-commit-log.yaml
@@ -19,4 +19,6 @@ topic_creation_config:
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
   retention.ms: "86400000"
+  segment.bytes: "104857600"
+  segment.ms: "3600000"
 partitions: 1 # Commit log topic must always have one partition

--- a/topics/snuba-transactions-commit-log.yaml
+++ b/topics/snuba-transactions-commit-log.yaml
@@ -19,4 +19,6 @@ topic_creation_config:
   cleanup.policy: compact,delete
   min.compaction.lag.ms: "3600000"
   retention.ms: "86400000"
+  segment.bytes: "104857600"
+  segment.ms: "3600000"
 partitions: 1 # Commit log topic must always have one partition


### PR DESCRIPTION
very large segments that roll over infrequently are problematic on commit log topics because the topics will roll over infrequently causing the topics to get too large. this is problematic for post process forwarders specifically which need to scan the entire commit log on startup.

these values are taken from the events and transactions commit log topics in sentry production, we need to actually apply them across the board.