### PR TITLE
fix: ingest-monitors topic configuration

### DIFF
--- a/topics/ingest-monitors.yaml
+++ b/topics/ingest-monitors.yaml
@@ -17,5 +17,4 @@ topic_creation_config:
   compression.type: lz4
   max.message.bytes: "10000000"
   message.timestamp.type: LogAppendTime
-  segment.bytes: "1073741824"
   retention.ms: "86400000"


### PR DESCRIPTION
this does not currently match actual config at sentry. we don't set this in production so it shouldn't be here.