### PR TITLE
fix max.message.bytes on ingest-replay-events

### DIFF
--- a/topics/ingest-replay-events.yaml
+++ b/topics/ingest-replay-events.yaml
@@ -17,5 +17,5 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   message.timestamp.type: LogAppendTime
-  max.message.bytes: "15000000"
+  max.message.bytes: "10000000"
   retention.ms: "86400000"


### PR DESCRIPTION
this does not match the value in sentry prod, they should align, and this will be validated by CI soon.

https://github.com/getsentry/ops/blob/4b204b222bebc275726a638618eb0e318970da7f/k8s/services/topicctl/_values.yaml#L93