### PR TITLE
fix snuba-spans max.message.bytes

### DIFF
--- a/topics/snuba-spans.yaml
+++ b/topics/snuba-spans.yaml
@@ -16,3 +16,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   retention.ms: "86400000"
+  max.message.bytes: "10000000"


### PR DESCRIPTION
we have 10mb set in production, let's also enforce that here as spans messages can be larger