### PR TITLE
fix message.timestamp.type on 3 topics

### DIFF
--- a/python/tests/test_sentry_kafka_schemas.py
+++ b/python/tests/test_sentry_kafka_schemas.py
@@ -8,6 +8,7 @@ def test_get_topic() -> None:
     assert topic_data["topic_creation_config"] == {
         "compression.type": "lz4",
         "max.message.bytes": "2000000",
+        "message.timestamp.type": "LogAppendTime",
         "retention.ms": "86400000",
     }
 

--- a/topics/snuba-metrics-summaries.yaml
+++ b/topics/snuba-metrics-summaries.yaml
@@ -15,3 +15,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   retention.ms: "86400000"
+  message.timestamp.type: LogAppendTime

--- a/topics/snuba-queries.yaml
+++ b/topics/snuba-queries.yaml
@@ -16,3 +16,4 @@ topic_creation_config:
   compression.type: lz4
   max.message.bytes: "2000000"
   retention.ms: "86400000"
+  message.timestamp.type: LogAppendTime

--- a/topics/snuba-spans.yaml
+++ b/topics/snuba-spans.yaml
@@ -17,3 +17,4 @@ topic_creation_config:
   compression.type: lz4
   retention.ms: "86400000"
   max.message.bytes: "10000000"
+  message.timestamp.type: LogAppendTime


### PR DESCRIPTION
this matches what we have set in sentry prod, these were incorrectly omitted here earlier