### PR TITLE
processed-profiles and profiles-call-tree have 50mb

### DIFF
--- a/topics/processed-profiles.yaml
+++ b/topics/processed-profiles.yaml
@@ -17,3 +17,4 @@ topic_creation_config:
   compression.type: lz4
   message.timestamp.type: LogAppendTime
   retention.ms: "86400000"
+  max.message.bytes: "50000000"

--- a/topics/profiles-call-tree.yaml
+++ b/topics/profiles-call-tree.yaml
@@ -17,3 +17,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   retention.ms: "86400000"
+  max.message.bytes: "50000000"


### PR DESCRIPTION
this seems ginormous but it matches what is defined in prod