### PR TITLE
rename partitions to enforced_partition_count

### DIFF
--- a/python/sentry_kafka_schemas/sentry_kafka_schemas.py
+++ b/python/sentry_kafka_schemas/sentry_kafka_schemas.py
@@ -51,7 +51,7 @@ class TopicData(TypedDict):
     schemas: Sequence[TopicSchema]
     pipeline: NotRequired[str]
     topic_creation_config: Mapping[str, str]
-    partitions: Optional[int]
+    enforced_partition_count: Optional[int]
 
 
 _TOPICS_PATH = Path.joinpath(Path(__file__).parent, "topics")
@@ -84,8 +84,8 @@ def get_topic(topic: str) -> TopicData:
     if "topic_creation_config" not in topic_data:
         topic_data["topic_creation_config"] = {}
 
-    if "partitions" not in topic_data:
-        topic_data["partitions"] = None
+    if "enforced_partition_count" not in topic_data:
+        topic_data["enforced_partition_count"] = None
 
     return topic_data
 

--- a/python/tests/test_sentry_kafka_schemas.py
+++ b/python/tests/test_sentry_kafka_schemas.py
@@ -12,9 +12,9 @@ def test_get_topic() -> None:
         "retention.ms": "86400000",
     }
 
-    assert topic_data["partitions"] is None
+    assert topic_data["enforced_partition_count"] is None
 
-    assert get_topic("snuba-commit-log")["partitions"] == 1
+    assert get_topic("snuba-commit-log")["enforced_partition_count"] == 1
 
 
 def test_get_schema() -> None:

--- a/topics/monitors-clock-tick.yaml
+++ b/topics/monitors-clock-tick.yaml
@@ -17,4 +17,4 @@ topic_creation_config:
   compression.type: lz4
   message.timestamp.type: LogAppendTime
   retention.ms: "86400000"
-partitions: 1 # monitors-clock-tick must always have one partition
+enforced_partition_count: 1 # monitors-clock-tick must always have one partition

--- a/topics/snuba-commit-log.yaml
+++ b/topics/snuba-commit-log.yaml
@@ -21,4 +21,4 @@ topic_creation_config:
   retention.ms: "86400000"
   segment.bytes: "104857600"
   segment.ms: "3600000"
-partitions: 1 # Commit log topic must always have one partition
+enforced_partition_count: 1 # Commit log topic must always have one partition

--- a/topics/snuba-generic-events-commit-log.yaml
+++ b/topics/snuba-generic-events-commit-log.yaml
@@ -21,4 +21,4 @@ topic_creation_config:
   retention.ms: "86400000"
   segment.bytes: "104857600"
   segment.ms: "3600000"
-partitions: 1 # Commit log topic must always have one partition
+enforced_partition_count: 1 # Commit log topic must always have one partition

--- a/topics/snuba-generic-metrics-counters-commit-log.yaml
+++ b/topics/snuba-generic-metrics-counters-commit-log.yaml
@@ -21,4 +21,4 @@ topic_creation_config:
   retention.ms: "86400000"
   segment.bytes: "104857600"
   segment.ms: "3600000"
-partitions: 1 # Commit log topic must always have one partition
+enforced_partition_count: 1 # Commit log topic must always have one partition

--- a/topics/snuba-generic-metrics-distributions-commit-log.yaml
+++ b/topics/snuba-generic-metrics-distributions-commit-log.yaml
@@ -21,4 +21,4 @@ topic_creation_config:
   retention.ms: "86400000"
   segment.bytes: "104857600"
   segment.ms: "3600000"
-partitions: 1 # Commit log topic must always have one partition
+enforced_partition_count: 1 # Commit log topic must always have one partition

--- a/topics/snuba-generic-metrics-gauges-commit-log.yaml
+++ b/topics/snuba-generic-metrics-gauges-commit-log.yaml
@@ -21,4 +21,4 @@ topic_creation_config:
   retention.ms: "86400000"
   segment.bytes: "104857600"
   segment.ms: "3600000"
-partitions: 1 # Commit log topic must always have one partition
+enforced_partition_count: 1 # Commit log topic must always have one partition

--- a/topics/snuba-generic-metrics-sets-commit-log.yaml
+++ b/topics/snuba-generic-metrics-sets-commit-log.yaml
@@ -21,4 +21,4 @@ topic_creation_config:
   retention.ms: "86400000"
   segment.bytes: "104857600"
   segment.ms: "3600000"
-partitions: 1 # Commit log topic must always have one partition
+enforced_partition_count: 1 # Commit log topic must always have one partition

--- a/topics/snuba-metrics-commit-log.yaml
+++ b/topics/snuba-metrics-commit-log.yaml
@@ -21,4 +21,4 @@ topic_creation_config:
   retention.ms: "86400000"
   segment.bytes: "104857600"
   segment.ms: "3600000"
-partitions: 1 # Commit log topic must always have one partition
+enforced_partition_count: 1 # Commit log topic must always have one partition

--- a/topics/snuba-transactions-commit-log.yaml
+++ b/topics/snuba-transactions-commit-log.yaml
@@ -21,4 +21,4 @@ topic_creation_config:
   retention.ms: "86400000"
   segment.bytes: "104857600"
   segment.ms: "3600000"
-partitions: 1 # Commit log topic must always have one partition
+enforced_partition_count: 1 # Commit log topic must always have one partition


### PR DESCRIPTION
@evanpurkhiser pointed out the name "partitions" was misleading on https://github.com/getsentry/sentry-kafka-schemas/pull/294