### PR TITLE
set 10mb max.message bytes for metrics topics

### DIFF
--- a/topics/ingest-metrics.yaml
+++ b/topics/ingest-metrics.yaml
@@ -17,3 +17,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   retention.ms: "86400000"
+  max.message.bytes: "10000000"

--- a/topics/ingest-performance-metrics.yaml
+++ b/topics/ingest-performance-metrics.yaml
@@ -16,3 +16,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   retention.ms: "86400000"
+  max.message.bytes: "10000000"

--- a/topics/snuba-generic-metrics.yaml
+++ b/topics/snuba-generic-metrics.yaml
@@ -17,3 +17,4 @@ topic_creation_config:
   compression.type: lz4
   message.timestamp.type: LogAppendTime
   retention.ms: "86400000"
+  max.message.bytes: "10000000"


### PR DESCRIPTION
ingest-metrics, ingest-performance-metrics and snuba-generic-metrics all have 10mb set in prod, we need to match it here