### PR TITLE
fix snuba-metrics-summaries

### DIFF
--- a/topics/snuba-metrics-summaries.yaml
+++ b/topics/snuba-metrics-summaries.yaml
@@ -15,3 +15,4 @@ topic_creation_config:
   compression.type: lz4
   retention.ms: "86400000"
   message.timestamp.type: LogAppendTime
+  max.message.bytes: "10000000"


### PR DESCRIPTION
it's 10mb in production, we need to set this here as well