### PR TITLE
add schema, examples and topic definition for ingest-occurrences

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,7 @@
 /topics/ingest-replay-recordings.yaml                          @getsentry/owners-snuba @getsentry/ingest @getsentry/replay
 /topics/ingest-feedback-events.yaml                            @getsentry/owners-snuba @getsentry/replay
 /topics/ingest-monitors.yaml                                   @getsentry/crons
+/topics/ingest-occurrences.yaml                                @getsentry/issues
 
 # DLQs for ingest topics
 /topics/ingest-events-dlq.yaml                                 @getsentry/ops

--- a/examples/ingest-occurrences/1/monitor-failure.json
+++ b/examples/ingest-occurrences/1/monitor-failure.json
@@ -17,7 +17,7 @@
     { "name": "Last successful check-in", "value": "Never", "important": false }
   ],
   "type": 4001,
-  "detection_time": 1717713781.100000,
+  "detection_time": 1717713781.1,
   "level": "error",
   "culprit": "",
   "initial_issue_priority": null,

--- a/examples/ingest-occurrences/1/monitor-failure.json
+++ b/examples/ingest-occurrences/1/monitor-failure.json
@@ -1,0 +1,59 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "project_id": 1,
+  "event_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "fingerprint": ["cccccccccccccccccccccccccccccccc"],
+  "issue_title": "Monitor failure: poll_service",
+  "subtitle": "Your monitor has reached its failure threshold.",
+  "resource_id": null,
+  "evidence_data": {},
+  "evidence_display": [
+    {
+      "name": "Failure reason",
+      "value": "A missed check-in was detected",
+      "important": true
+    },
+    { "name": "Environment", "value": "us", "important": false },
+    { "name": "Last successful check-in", "value": "Never", "important": false }
+  ],
+  "type": 4001,
+  "detection_time": 1717713781.100000,
+  "level": "error",
+  "culprit": "",
+  "initial_issue_priority": null,
+  "assignee": null,
+  "payload_type": "occurrence",
+  "event": {
+    "contexts": {
+      "monitor": {
+        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "slug": "poll_service",
+        "name": "poll_service",
+        "config": {
+          "schedule": "*/1 * * * *",
+          "checkin_margin": null,
+          "max_runtime": null,
+          "timezone": "UTC",
+          "failure_issue_threshold": null,
+          "recovery_threshold": null,
+          "schedule_type": 1
+        },
+        "status": "error",
+        "type": "cron_job"
+      }
+    },
+    "environment": "us",
+    "event_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "fingerprint": ["cccccccccccccccccccccccccccccccc"],
+    "platform": "other",
+    "project_id": 1,
+    "received": "2024-06-06T22:43:01.100000+00:00",
+    "sdk": null,
+    "tags": {
+      "monitor.id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      "monitor.slug": "poll_service",
+      "monitor.incident": "12345"
+    },
+    "timestamp": "2024-06-06T22:43:01.100000+00:00"
+  }
+}

--- a/schemas/ingest-occurrences.v1.schema.json
+++ b/schemas/ingest-occurrences.v1.schema.json
@@ -6,18 +6,15 @@
     "id": { "type": "string" },
     "project_id": { "type": "integer" },
     "fingerprint": { "type": "array", "items": { "type": "string" } },
-    "issue_title": { "type": "string" },
-    "subtitle": { "type": "string" },
-    "type": { "type": "integer" },
-    "initial_issue_priority": { "type": ["null", "integer"] },
-    "payload_type": { "type": "string" }
+    "issue_title": { "type": ["string", "null"] },
+    "subtitle": { "type": ["string", "null"] },
+    "type": { "type": ["integer", "null"] },
+    "initial_issue_priority": { "type": ["integer", "null"] },
+    "payload_type": {"type": ["string", "null"] }
   },
   "required": [
     "id",
     "project_id",
-    "fingerprint",
-    "issue_title",
-    "subtitle",
-    "type"
+    "fingerprint"
   ]
 }

--- a/schemas/ingest-occurrences.v1.schema.json
+++ b/schemas/ingest-occurrences.v1.schema.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Issue occurrence",
+    "type": "object",
+    "properties": {
+        "id": {"type": "string"},
+        "project_id": {"type": "integer"},
+        "fingerprint": { "type": "array", "items": { "type": "string" } },
+        "issue_title": {"type": "string"},
+        "subtitle": {"type": "string"},
+        "type": {"type": "integer"},
+        "initial_issue_priority": {"type": ["null", "integer"]}
+    },
+    "required": ["id", "project_id", "fingerprint", "issue_title", "subtitle", "type"]
+}

--- a/schemas/ingest-occurrences.v1.schema.json
+++ b/schemas/ingest-occurrences.v1.schema.json
@@ -10,7 +10,7 @@
     "subtitle": { "type": "string" },
     "type": { "type": "integer" },
     "initial_issue_priority": { "type": ["null", "integer"] },
-    "payload_type": {"type": "string"}
+    "payload_type": { "type": "string" }
   },
   "required": [
     "id",

--- a/schemas/ingest-occurrences.v1.schema.json
+++ b/schemas/ingest-occurrences.v1.schema.json
@@ -1,15 +1,22 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "description": "Issue occurrence",
-    "type": "object",
-    "properties": {
-        "id": {"type": "string"},
-        "project_id": {"type": "integer"},
-        "fingerprint": { "type": "array", "items": { "type": "string" } },
-        "issue_title": {"type": "string"},
-        "subtitle": {"type": "string"},
-        "type": {"type": "integer"},
-        "initial_issue_priority": {"type": ["null", "integer"]}
-    },
-    "required": ["id", "project_id", "fingerprint", "issue_title", "subtitle", "type"]
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Issue occurrence",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "project_id": { "type": "integer" },
+    "fingerprint": { "type": "array", "items": { "type": "string" } },
+    "issue_title": { "type": "string" },
+    "subtitle": { "type": "string" },
+    "type": { "type": "integer" },
+    "initial_issue_priority": { "type": ["null", "integer"] }
+  },
+  "required": [
+    "id",
+    "project_id",
+    "fingerprint",
+    "issue_title",
+    "subtitle",
+    "type"
+  ]
 }

--- a/schemas/ingest-occurrences.v1.schema.json
+++ b/schemas/ingest-occurrences.v1.schema.json
@@ -9,7 +9,8 @@
     "issue_title": { "type": "string" },
     "subtitle": { "type": "string" },
     "type": { "type": "integer" },
-    "initial_issue_priority": { "type": ["null", "integer"] }
+    "initial_issue_priority": { "type": ["null", "integer"] },
+    "payload_type": {"type": "string"}
   },
   "required": [
     "id",

--- a/schemas/ingest-occurrences.v1.schema.json
+++ b/schemas/ingest-occurrences.v1.schema.json
@@ -10,11 +10,7 @@
     "subtitle": { "type": ["string", "null"] },
     "type": { "type": ["integer", "null"] },
     "initial_issue_priority": { "type": ["integer", "null"] },
-    "payload_type": {"type": ["string", "null"] }
+    "payload_type": { "type": ["string", "null"] }
   },
-  "required": [
-    "id",
-    "project_id",
-    "fingerprint"
-  ]
+  "required": ["id", "project_id", "fingerprint"]
 }

--- a/topics/ingest-occurrences.yaml
+++ b/topics/ingest-occurrences.yaml
@@ -1,0 +1,17 @@
+pipeline: generic-events
+description: Issue occurence data
+services:
+  producers:
+    - getsentry/sentry
+  consumers:
+    - getsentry/sentry
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: json
+    resource: ingest-occurrences.v1.schema.json
+    examples:
+      - ingest-occurrences/1/
+topic_creation_config:
+  compression.type: lz4
+  retention.ms: "86400000"


### PR DESCRIPTION
we need to add all the missing topics here so they can be used to generate topic/consumer group configuration in prod

i figured out the schema/required fields by reading the consumer code in https://github.com/getsentry/sentry/blob/671811bab8661ea5bd7c1dc95cd5bc341bf8a22d/src/sentry/issues/occurrence_consumer.py