### PR TITLE
fix(uptime): Add `subscription_id` and remove monitor related ids

### DIFF
--- a/examples/uptime-results/1/failure.json
+++ b/examples/uptime-results/1/failure.json
@@ -1,7 +1,6 @@
 {
   "guid": "54afc7ed9c53491481919c931f75bae1",
-  "monitor_id": 1,
-  "monitor_environment_id": 1,
+  "subscription_id": "5421b5df80744113a6b57014f01a3a42",
   "status": "failure",
   "status_reason": {
     "type": "dns_error",

--- a/examples/uptime-results/1/succeess.json
+++ b/examples/uptime-results/1/succeess.json
@@ -1,7 +1,6 @@
 {
   "guid": "54afc7ed9c53491481919c931f75bae1",
-  "monitor_id": 1,
-  "monitor_environment_id": 1,
+  "subscription_id": "5421b5df80744113a6b57014f01a3a42",
   "status": "success",
   "status_reason": null,
   "trace_id": "947efba02dac463b9c1d886a44bafc94",

--- a/examples/uptime-results/1/timeout.json
+++ b/examples/uptime-results/1/timeout.json
@@ -1,7 +1,6 @@
 {
   "guid": "54afc7ed9c53491481919c931f75bae1",
-  "monitor_id": 1,
-  "monitor_environment_id": 1,
+  "subscription_id": "5421b5df80744113a6b57014f01a3a42",
   "status": "failure",
   "status_reason": {
     "type": "timeout",

--- a/schemas/uptime-results.v1.schema.json
+++ b/schemas/uptime-results.v1.schema.json
@@ -61,17 +61,9 @@
           "description": "Unique identifier of the uptime check",
           "type": "string"
         },
-        "monitor_id": {
-          "description": "The identifier of the uptime monitor",
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 18446744073709551615
-        },
-        "monitor_environment_id": {
-          "description": "The identifier of the uptime monitors environment",
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 18446744073709551615
+        "subscription_id": {
+          "description": "Identifier of the subscription that this check was run for",
+          "type": "string"
         },
         "status": {
           "$ref": "#/definitions/CheckStatus"
@@ -115,8 +107,7 @@
       },
       "required": [
         "guid",
-        "monitor_id",
-        "monitor_environment_id",
+        "subscription_id",
         "status",
         "status_reason",
         "trace_id",


### PR DESCRIPTION
We don't want this system to be aware of the details of which system is consuming it, so just use a subscription id to keep track of things