### PR TITLE
fix(group-attributes): Update first_release_id field to integer or null

### DIFF
--- a/schemas/group-attributes.v1.schema.json
+++ b/schemas/group-attributes.v1.schema.json
@@ -25,7 +25,7 @@
           "type": ["integer", "null"]
         },
         "first_release_id": {
-          "$ref": "#/definitions/GroupAttributesSnapshot/UUID"
+          "type": ["integer", "null"]
         },
         "first_seen": {
           "type": "string"
@@ -74,12 +74,7 @@
         "owner_codeowners_user_id",
         "owner_codeowners_team_id",
         "timestamp"
-      ],
-      "UUID": {
-        "type": "string",
-        "minLength": 32,
-        "maxLength": 36
-      }
+      ]
     }
   }
 }


### PR DESCRIPTION
This field was added to GroupAttributes as UUID but release IDs are bigints. We're updating the column in the table and the schema should be updated to match as well. 

The `first_release_id` field isn't populated anywhere yet so this is a safe change.