### PR TITLE
fix(group-attributes): Update name for field to `first_release`

### DIFF
--- a/schemas/group-attributes.v1.schema.json
+++ b/schemas/group-attributes.v1.schema.json
@@ -24,7 +24,7 @@
         "priority": {
           "type": ["integer", "null"]
         },
-        "first_release_id": {
+        "first_release": {
           "type": ["integer", "null"]
         },
         "first_seen": {


### PR DESCRIPTION
Updating the name for this field to `first_release` to match the column, `GroupAttributes.group_first_release`. This field is still unused so the name change shouldn't affect any producers.