### PR TITLE
ensure dlq topics have the same message size as their underlying topics

### DIFF
--- a/python/tests/test_valid_topic_data.py
+++ b/python/tests/test_valid_topic_data.py
@@ -163,3 +163,24 @@ def test_retention() -> None:
             error = f"Invalid retention for topic {topic_name}: {retention}"
 
         assert retention in allowed, error
+
+
+def test_dlq_configuration() -> None:
+    # This file does not match the naming convention
+    custom_dlq_mapping = {
+        "ingest-generic-metrics-dlq": "ingest-performance-metrics"
+    }
+
+    topics_dir = _TOPICS
+    for filename in topics_dir.iterdir():
+        if filename.stem.endswith("-dlq"):
+            main_topic_name = custom_dlq_mapping.get(filename.stem, filename.stem[:-4])
+            with open(filename) as dlq_file, open(f"{filename.parent}/{main_topic_name}.yaml") as main_topic_file:
+                dlq_topic_data = safe_load(dlq_file)
+                main_topic_data = safe_load(main_topic_file)
+
+                # max.message.bytes matches
+                assert dlq_topic_data["topic_creation_config"].get("max.message.bytes") == main_topic_data["topic_creation_config"].get("max.message.bytes")
+
+                # DLQ has 7 day retention
+                assert dlq_topic_data["topic_creation_config"]["retention.ms"] == str(7 * 1000 * 60 * 60 * 24)

--- a/python/tests/test_valid_topic_data.py
+++ b/python/tests/test_valid_topic_data.py
@@ -176,12 +176,15 @@ def test_dlq_configuration() -> None:
     }
 
     topics_dir = _TOPICS
-    for filename in topics_dir.iterdir():
-        if filename.stem.endswith("-dlq"):
-            main_topic_name = custom_dlq_mapping.get(filename.stem, filename.stem[:-4])
+    dlq_suffix = "-dlq"
+    snuba_dlq_prefix = "snuba-dead-letter-"
 
-        elif filename.stem.startswith("snuba-dead-letter-"):
-            main_topic_name = custom_dlq_mapping.get(filename.stem, filename.stem[18:])
+    for filename in topics_dir.iterdir():
+        if filename.stem.endswith(dlq_suffix):
+            main_topic_name = custom_dlq_mapping.get(filename.stem, filename.stem[:-len(dlq_suffix)])
+
+        elif filename.stem.startswith(snuba_dlq_prefix):
+            main_topic_name = custom_dlq_mapping.get(filename.stem, filename.stem[len(snuba_dlq_prefix):])
         else:
             continue
 

--- a/python/tests/test_valid_topic_data.py
+++ b/python/tests/test_valid_topic_data.py
@@ -181,10 +181,14 @@ def test_dlq_configuration() -> None:
 
     for filename in topics_dir.iterdir():
         if filename.stem.endswith(dlq_suffix):
-            main_topic_name = custom_dlq_mapping.get(filename.stem, filename.stem[:-len(dlq_suffix)])
+            main_topic_name = custom_dlq_mapping.get(
+                filename.stem, filename.stem[: -len(dlq_suffix)]
+            )
 
         elif filename.stem.startswith(snuba_dlq_prefix):
-            main_topic_name = custom_dlq_mapping.get(filename.stem, filename.stem[len(snuba_dlq_prefix):])
+            main_topic_name = custom_dlq_mapping.get(
+                filename.stem, filename.stem[len(snuba_dlq_prefix) :]
+            )
         else:
             continue
 

--- a/python/tests/test_valid_topic_data.py
+++ b/python/tests/test_valid_topic_data.py
@@ -166,8 +166,7 @@ def test_retention() -> None:
 
 
 def test_dlq_configuration() -> None:
-    # This file does not match the naming convention
-
+    # These topics do not match the naming conventions
     custom_dlq_mapping = {
         "ingest-generic-metrics-dlq": "ingest-performance-metrics",
         "snuba-dead-letter-replays": "ingest-replay-events",

--- a/python/tests/test_valid_topic_data.py
+++ b/python/tests/test_valid_topic_data.py
@@ -167,20 +167,25 @@ def test_retention() -> None:
 
 def test_dlq_configuration() -> None:
     # This file does not match the naming convention
-    custom_dlq_mapping = {
-        "ingest-generic-metrics-dlq": "ingest-performance-metrics"
-    }
+    custom_dlq_mapping = {"ingest-generic-metrics-dlq": "ingest-performance-metrics"}
 
     topics_dir = _TOPICS
     for filename in topics_dir.iterdir():
         if filename.stem.endswith("-dlq"):
             main_topic_name = custom_dlq_mapping.get(filename.stem, filename.stem[:-4])
-            with open(filename) as dlq_file, open(f"{filename.parent}/{main_topic_name}.yaml") as main_topic_file:
+            with (
+                open(filename) as dlq_file,
+                open(f"{filename.parent}/{main_topic_name}.yaml") as main_topic_file,
+            ):
                 dlq_topic_data = safe_load(dlq_file)
                 main_topic_data = safe_load(main_topic_file)
 
                 # max.message.bytes matches
-                assert dlq_topic_data["topic_creation_config"].get("max.message.bytes") == main_topic_data["topic_creation_config"].get("max.message.bytes")
+                assert dlq_topic_data["topic_creation_config"].get(
+                    "max.message.bytes"
+                ) == main_topic_data["topic_creation_config"].get("max.message.bytes")
 
                 # DLQ has 7 day retention
-                assert dlq_topic_data["topic_creation_config"]["retention.ms"] == str(7 * 1000 * 60 * 60 * 24)
+                assert dlq_topic_data["topic_creation_config"]["retention.ms"] == str(
+                    7 * 1000 * 60 * 60 * 24
+                )

--- a/python/tests/test_valid_topic_data.py
+++ b/python/tests/test_valid_topic_data.py
@@ -186,12 +186,19 @@ def test_dlq_configuration() -> None:
         else:
             continue
 
-        with open(filename) as dlq_file, open(f"{filename.parent}/{main_topic_name}.yaml") as main_topic_file:
+        with (
+            open(filename) as dlq_file,
+            open(f"{filename.parent}/{main_topic_name}.yaml") as main_topic_file,
+        ):
             dlq_topic_data = safe_load(dlq_file)
             main_topic_data = safe_load(main_topic_file)
 
             # max.message.bytes matches
-            assert dlq_topic_data["topic_creation_config"].get("max.message.bytes") == main_topic_data["topic_creation_config"].get("max.message.bytes")
+            assert dlq_topic_data["topic_creation_config"].get(
+                "max.message.bytes"
+            ) == main_topic_data["topic_creation_config"].get("max.message.bytes")
 
             # DLQ has 7 day retention
-            assert dlq_topic_data["topic_creation_config"]["retention.ms"] == str(7 * 1000 * 60 * 60 * 24)
+            assert dlq_topic_data["topic_creation_config"]["retention.ms"] == str(
+                7 * 1000 * 60 * 60 * 24
+            )

--- a/topics/buffered-segments-dlq.yaml
+++ b/topics/buffered-segments-dlq.yaml
@@ -13,3 +13,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   retention.ms: "604800000" # 7 days
+  max.message.bytes: "10000000"

--- a/topics/ingest-attachments-dlq.yaml
+++ b/topics/ingest-attachments-dlq.yaml
@@ -14,3 +14,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   retention.ms: "604800000" # 7 days
+  max.message.bytes: "10000000"

--- a/topics/ingest-generic-metrics-dlq.yaml
+++ b/topics/ingest-generic-metrics-dlq.yaml
@@ -14,3 +14,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   retention.ms: "604800000" # 7 days
+  max.message.bytes: "10000000"

--- a/topics/ingest-metrics-dlq.yaml
+++ b/topics/ingest-metrics-dlq.yaml
@@ -14,3 +14,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   retention.ms: "604800000" # 7 days
+  max.message.bytes: "10000000"

--- a/topics/snuba-dead-letter-generic-metrics.yaml
+++ b/topics/snuba-dead-letter-generic-metrics.yaml
@@ -14,3 +14,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   retention.ms: "604800000" # 7 days
+  max.message.bytes: "10000000"

--- a/topics/snuba-dead-letter-querylog.yaml
+++ b/topics/snuba-dead-letter-querylog.yaml
@@ -14,3 +14,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   retention.ms: "604800000" # 7 days
+  max.message.bytes: "50000000"

--- a/topics/snuba-dead-letter-replays.yaml
+++ b/topics/snuba-dead-letter-replays.yaml
@@ -14,3 +14,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   retention.ms: "604800000" # 7 days
+  max.message.bytes: "10000000"


### PR DESCRIPTION
fix `buffered-segments-dlq`, `ingest-attachments-dlq`, `ingest-metrics-dlq` and `ingest-generic-metrics-dlq`, `snuba-dead-letter-generic-metrics`, `snuba-dead-letter-querylog`, `snuba-dead-letter-replays`

also adds a test