### PR TITLE
feat(generic-metrics): Add optional sample rate

### DIFF
--- a/examples/ingest-metrics/1/sampled-distribution.json
+++ b/examples/ingest-metrics/1/sampled-distribution.json
@@ -1,0 +1,11 @@
+{
+  "name": "d:transactions/duration@millisecond",
+  "org_id": 1,
+  "retention_days": 90,
+  "project_id": 42,
+  "tags": {},
+  "type": "d",
+  "value": [1.0, 2.0, 3.0],
+  "timestamp": 666666666666,
+  "sample_rate": 0.1
+}

--- a/examples/snuba-generic-metrics/1/snuba-generic-metrics-dist-sampled.json
+++ b/examples/snuba-generic-metrics/1/snuba-generic-metrics-dist-sampled.json
@@ -1,0 +1,26 @@
+{
+  "version": 2,
+  "use_case_id": "spans",
+  "org_id": 1,
+  "project_id": 3,
+  "metric_id": 65563,
+  "timestamp": 1704614940,
+  "sentry_received_timestamp": 1704614940,
+  "tags": {
+    "9223372036854776010": "production",
+    "9223372036854776017": "healthy",
+    "65690": "metric_e2e_spans_dist_v_VUW93LMS"
+  },
+  "retention_days": 90,
+  "mapping_meta": {
+    "d": { "65560": "d:spans/duration@second" },
+    "h": {
+      "9223372036854776017": "session.status",
+      "9223372036854776010": "environment"
+    },
+    "f": { "65691": "metric_e2e_spans_dist_k_VUW93LMS" }
+  },
+  "type": "d",
+  "value": { "format": "array", "data": [0.0, 1.1, 2.2, 3.3, 4.4, 5.5] },
+  "sample_rate": 0.1
+}

--- a/schemas/ingest-metrics.v1.schema.json
+++ b/schemas/ingest-metrics.v1.schema.json
@@ -149,6 +149,12 @@
           "type": "integer",
           "minimum": 0,
           "maximum": 18446744073709551615
+        },
+        "sample_rate": {
+          "description": "The sample rate of the metric bucket. This is a float between 0 and 1.",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
         }
       },
       "required": [

--- a/schemas/snuba-generic-metrics.v1.schema.json
+++ b/schemas/snuba-generic-metrics.v1.schema.json
@@ -135,6 +135,9 @@
         "retention_days": {
           "type": "integer"
         },
+        "sample_rate": {
+          "type": "number"
+        },
         "mapping_meta": {
           "$ref": "#/definitions/MappingMeta"
         },


### PR DESCRIPTION
Introduces a floating point sample rate field with values ranging from `0.0` to `1.0`. The field is optional for backwards compatibility and defaults to `1.0`.

**Resources**:
- [Project Doc](https://www.notion.so/sentry/Metrics-Extrapolation-a5e2fd4ed854400d81792e85ae6e0732)
- [Tech Spec](https://www.notion.so/sentry/Tech-Spec-Query-Time-Metric-Extrapolation-2e0603a58a794fe6a84b57e8c6740b9b)