### PR TITLE
fix(generic-metrics): Use floating point as sample weight

### DIFF
--- a/examples/snuba-metrics/1/snuba-metrics-sampled.json
+++ b/examples/snuba-metrics/1/snuba-metrics-sampled.json
@@ -12,7 +12,7 @@
   },
   "value": [324234, 345345, 456456, 567567],
   "retention_days": 22,
-  "sample_weight": 100,
+  "sample_weight": 100.1,
   "mapping_meta": {
     "c": {
       "10": "tag-1",

--- a/schemas/ingest-metrics.v1.schema.json
+++ b/schemas/ingest-metrics.v1.schema.json
@@ -151,7 +151,9 @@
           "maximum": 18446744073709551615
         },
         "sample_weight": {
-          "type": "integer"
+          "type": "number",
+          "minimum": 1,
+          "maximum": 18446744073709551615
         }
       },
       "required": [

--- a/schemas/snuba-generic-metrics.v1.schema.json
+++ b/schemas/snuba-generic-metrics.v1.schema.json
@@ -142,7 +142,9 @@
           "type": "string"
         },
         "sample_weight": {
-          "type": "integer"
+          "type": "number",
+          "minimum": 1,
+          "maximum": 18446744073709551615
         }
       },
       "required": [


### PR DESCRIPTION
### Overview

Use floating point as weights instead of integers