### PR TITLE
fix(uptime): Require span_id

### DIFF
--- a/schemas/uptime-results.v1.schema.json
+++ b/schemas/uptime-results.v1.schema.json
@@ -115,6 +115,7 @@
         "status",
         "status_reason",
         "trace_id",
+        "span_id",
         "scheduled_check_time_ms",
         "actual_check_time_ms",
         "duration_ms",


### PR DESCRIPTION
This is already always being set by the uptime checker. Correct the schema to match what we're doing