### PR TITLE
ref(uptime): Allow additional methods in `request_type`

### DIFF
--- a/schemas/uptime-results.v1.schema.json
+++ b/schemas/uptime-results.v1.schema.json
@@ -19,7 +19,7 @@
       "title": "request_type",
       "description": "The type of HTTP method used for the check",
       "type": "string",
-      "enum": ["HEAD", "GET"]
+      "enum": ["GET", "POST", "HEAD", "PUT", "DELETE", "PATCH", "OPTIONS"]
     },
     "CheckStatusReason": {
       "title": "check_status_reason",


### PR DESCRIPTION
Since this is now configurable via the check config.