### PR TITLE
chore(github): Bump `upload-artifact` to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: 3.11
       - run: make build
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: github.event_name != 'pull_request'
         with:
           name: ${{ github.sha }}


### PR DESCRIPTION
The release action is now failing, seeing if just bumping this fixes it