### PR TITLE
ref(uptime): Switch request_headers to a array of tuples

### DIFF
--- a/examples/uptime-configs/1/example-post.msgpack
+++ b/examples/uptime-configs/1/example-post.msgpack
@@ -1,1 +1,1 @@
-‡¯subscription_idÙ d7629c6c82be4f679ee78a0d977856d2£url°http://sentry.io°interval_secondsÍ,ªtimeout_msÍô®request_method¤POST¯request_headersƒ­Authorization¬Bearer 12345¬Content-Type°application/json²X-My-Custom-Header­example value¬request_body°{"key": "value"}
+‡¯subscription_idÙ d7629c6c82be4f679ee78a0d977856d2£url°http://sentry.io°interval_secondsÍ,ªtimeout_msÍô®request_method¤POST¯request_headers“’­Authorization¬Bearer 12345’¬Content-Type°application/json’²X-My-Custom-Header­example value¬request_body°{"key": "value"}

--- a/schemas/uptime-configs.v1.schema.json
+++ b/schemas/uptime-configs.v1.schema.json
@@ -9,6 +9,21 @@
       "type": "number",
       "enum": [60, 300, 600, 1200, 1800, 3600]
     },
+    "RequestHeader": {
+      "title": "request_header",
+      "description": "An individual header, consisting of a name and value as a tuple.",
+      "type": "array",
+      "prefixItems": [
+        {
+          "title": "header_name",
+          "type": "string"
+        },
+        {
+          "title": "header_value",
+          "type": "string"
+        }
+      ]
+    },
     "CheckConfig": {
       "title": "check_config",
       "description": "A message containing the configuration for a check to scheduled and executed by the uptime-checker.",
@@ -37,9 +52,9 @@
         },
         "request_headers": {
           "description": "Additional HTTP headers to send with the request",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RequestHeader"
           }
         },
         "request_body": {


### PR DESCRIPTION
This allows multiple headers with the same name, as well as ordering consistencies.