### PR TITLE
Changes the schema so Querylog can use `progress_bytes` instead of `bytes`

### DIFF
--- a/examples/snuba-queries/1/snuba-queries-empty-trace-id.json
+++ b/examples/snuba-queries/1/snuba-queries-empty-trace-id.json
@@ -64,6 +64,7 @@
       },
       "result_profile": {
         "bytes": 1305,
+        "progress_bytes": 0,
         "blocks": 1,
         "rows": 22,
         "elapsed": 0.009863138198852539

--- a/examples/snuba-queries/1/snuba-queries1.json
+++ b/examples/snuba-queries/1/snuba-queries1.json
@@ -64,6 +64,7 @@
       },
       "result_profile": {
         "bytes": 1305,
+        "progress_bytes": 0,
         "blocks": 1,
         "rows": 22,
         "elapsed": 0.009863138198852539

--- a/examples/snuba-queries/1/with-organization-id.json
+++ b/examples/snuba-queries/1/with-organization-id.json
@@ -64,6 +64,7 @@
       },
       "result_profile": {
         "bytes": 1305,
+        "progress_bytes": 0,
         "blocks": 1,
         "rows": 22,
         "elapsed": 0.009863138198852539

--- a/schemas/snuba-queries.v1.schema.json
+++ b/schemas/snuba-queries.v1.schema.json
@@ -175,6 +175,10 @@
               "type": "integer",
               "minimum": 0
             },
+            "progress_bytes": {
+              "type": "integer",
+              "minimum": 0
+            },
             "elapsed": {
               "type": "number"
             }


### PR DESCRIPTION
unblocks https://github.com/getsentry/snuba/pull/6371