### PR TITLE
Add topic configurations required for EAP alerts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -61,6 +61,7 @@
 /topics/snuba-generic-metrics-counters-commit-log.yaml         @getsentry/owners-snuba
 /topics/snuba-generic-metrics-gauges-commit-log.yaml           @getsentry/owners-snuba
 /topics/snuba-generic-events-commit-log.yaml                   @getsentry/owners-snuba @getsentry/issues
+/topics/snuba-eap-spans-commit-log.yaml                        @getsentry/owners-snuba
 
 # Topics produced to by Snuba and Sentry
 /topics/shared-resources-usage.yaml                            @getsentry/owners-snuba @getsentry/data
@@ -117,6 +118,7 @@
 /topics/scheduled-subscriptions-generic-metrics-sets.yaml           @getsentry/owners-snuba
 /topics/scheduled-subscriptions-generic-metrics-distributions.yaml  @getsentry/owners-snuba
 /topics/scheduled-subscriptions-generic-metrics-gauges.yaml         @getsentry/owners-snuba
+/topics/scheduled-subscriptions-eap-spans.yaml                      @getsentry/owners-snuba @getsentry/performance
 
 # Subscription results published by Snuba for Sentry's result consumer
 /topics/events-subscription-results.yaml                            @getsentry/owners-snuba @getsentry/issues
@@ -125,3 +127,4 @@
 /topics/generic-metrics-subscription-results.yaml                   @getsentry/owners-snuba @getsentry/issues
 /schemas/subscription-result.v1.schema.json                         @getsentry/owners-snuba @getsentry/issues
 /examples/subscription-results/                                     @getsentry/owners-snuba @getsentry/issues
+/topics/eap-spans-subscription-results.yaml                         @getsentry/owners-snuba @getsentry/issues @getsentry/performance

--- a/topics/eap-spans-subscription-results.yaml
+++ b/topics/eap-spans-subscription-results.yaml
@@ -1,0 +1,16 @@
+description: EAP Spans Subscription Results
+services:
+  producers:
+    - getsentry/snuba
+  consumers:
+    - getsentry/sentry
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: json
+    resource: subscription-results.v1.schema.json
+    examples:
+      - subscription-results/1/
+topic_creation_config:
+  compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/scheduled-subscriptions-eap-spans.yaml
+++ b/topics/scheduled-subscriptions-eap-spans.yaml
@@ -1,0 +1,16 @@
+description: Scheduled subscriptions EAP spans
+services:
+  producers:
+    - getsentry/snuba
+  consumers:
+    - getsentry/snuba
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: json
+    resource: subscription-scheduled.v1.schema.json
+    examples:
+      - subscription-scheduled/1/
+topic_creation_config:
+  compression.type: lz4
+  retention.ms: "86400000"

--- a/topics/snuba-eap-spans-commit-log.yaml
+++ b/topics/snuba-eap-spans-commit-log.yaml
@@ -1,0 +1,21 @@
+description: Commit log topic for eap spans pipeline
+services:
+  producers:
+    - getsentry/snuba
+  consumers:
+    - getsentry/snuba
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: json
+    resource: any.json
+    examples:
+      - snuba-commit-log/1/
+topic_creation_config:
+  compression.type: lz4
+  cleanup.policy: compact,delete
+  min.compaction.lag.ms: "3600000"
+  retention.ms: "86400000"
+  segment.bytes: "104857600"
+  segment.ms: "3600000"
+enforced_partition_count: 1 # Commit log topic must always have one partition


### PR DESCRIPTION
These topic configurations are identical to other event type subscription topics (and are expected to be so)