### PR TITLE
feat(crons): Add "volume_anomaly_result" result to clock-tick

### DIFF
--- a/examples/monitors-clock-tick/1/example-volume-abnormal.json
+++ b/examples/monitors-clock-tick/1/example-volume-abnormal.json
@@ -1,0 +1,4 @@
+{
+  "ts": 1714072962,
+  "volume_anomaly_result": "abnormal"
+}

--- a/examples/monitors-clock-tick/1/example-volume-normal.json
+++ b/examples/monitors-clock-tick/1/example-volume-normal.json
@@ -1,0 +1,4 @@
+{
+  "ts": 1714072962,
+  "volume_anomaly_result": "normal"
+}

--- a/schemas/monitors-clock-tick.v1.schema.json
+++ b/schemas/monitors-clock-tick.v1.schema.json
@@ -12,6 +12,11 @@
         "ts": {
           "description": "The timestamp the clock ticked at.",
           "type": "number"
+        },
+        "volume_anomaly_result": {
+          "description": "The result of the volume anomaly detection for the minute that has been ticked past.",
+          "type": "string",
+          "enum": ["normal", "abnormal"]
         }
       },
       "required": ["ts"]


### PR DESCRIPTION
This will be used to inform the clock tick tasks that the tick detected
an abnormal amount of check-in volume for the previous minute.

Part of https://github.com/getsentry/sentry/issues/79328