### PR TITLE
feat(crons): Add `mark_unknown` clock task

### DIFF
--- a/examples/monitors-clock-tasks/1/mark_unknown.json
+++ b/examples/monitors-clock-tasks/1/mark_unknown.json
@@ -1,0 +1,6 @@
+{
+  "type": "mark_unknown",
+  "ts": 1714072962,
+  "monitor_environment_id": 1,
+  "checkin_id": 1
+}

--- a/schemas/monitors-clock-tasks.v1.schema.json
+++ b/schemas/monitors-clock-tasks.v1.schema.json
@@ -6,6 +6,9 @@
       "$ref": "#/definitions/MonitorsMarkTimeout"
     },
     {
+      "$ref": "#/definitions/MonitorsMarkUnknown"
+    },
+    {
       "$ref": "#/definitions/MonitorsMarkMissing"
     }
   ],
@@ -30,6 +33,31 @@
         },
         "checkin_id": {
           "description": "The check-in ID to mark as timed out.",
+          "type": "number"
+        }
+      },
+      "required": ["type", "ts", "monitor_environment_id", "checkin_id"]
+    },
+    "MonitorsMarkUnknown": {
+      "type": "object",
+      "title": "mark_unknown",
+      "description": "Indicates this monitor was in-progress when an anomolys click-tick was processed, meaning we are unable to know if a check-in may have been lost for this monitor.",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "Discriminant marker identifying the task.",
+          "enum": ["mark_unknown"]
+        },
+        "ts": {
+          "description": "The timestamp the clock ticked at.",
+          "type": "number"
+        },
+        "monitor_environment_id": {
+          "description": "The monitor environment ID to generate a missed check-in for.",
+          "type": "number"
+        },
+        "checkin_id": {
+          "description": "The check-in ID to mark as unknown.",
           "type": "number"
         }
       },


### PR DESCRIPTION
This task will be triggered when we detect an anomaly in check-in
volume during a clock tick. When this happens we are unable to know that
all check-ins before that tick have been received and will need to mark
all in-progress monitors as resulting in a 'unknown' state.

Part of https://github.com/getsentry/sentry/issues/79328