### PR TITLE
feat(crons): Add `volume_anomaly_result` to mark_missing task

### DIFF
--- a/examples/monitors-clock-tasks/1/mark_missing_abnormal.json
+++ b/examples/monitors-clock-tasks/1/mark_missing_abnormal.json
@@ -2,5 +2,5 @@
   "type": "mark_missing",
   "ts": 1714072962,
   "monitor_environment_id": 1,
-  "volume_anomaly_result": "normal"
+  "volume_anomaly_result": "abnormal"
 }

--- a/schemas/monitors-clock-tasks.v1.schema.json
+++ b/schemas/monitors-clock-tasks.v1.schema.json
@@ -49,6 +49,11 @@
           "description": "The timestamp the clock ticked at.",
           "type": "number"
         },
+        "volume_anomaly_result": {
+          "description": "The result of the volume anomaly detection for the minute that has been ticked past. Abnormal ticks cause misses to be recored as unknown.",
+          "type": "string",
+          "enum": ["normal", "abnormal"]
+        },
         "monitor_environment_id": {
           "description": "The monitor environment ID to generate a missed check-in for.",
           "type": "number"


### PR DESCRIPTION
When a clock tick is marked as having an abnormal volume we may have
lost check-is that should have been processed during this minute. In
this scenario we do not want to notify on misses, and instead should
create them as unknown misses.

Part of https://github.com/getsentry/sentry/issues/79328