### PR TITLE
fix(crons): Switch to `enum` as a shape Discriminator in clock tasks

### DIFF
--- a/schemas/monitors-clock-tasks.v1.schema.json
+++ b/schemas/monitors-clock-tasks.v1.schema.json
@@ -18,7 +18,7 @@
       "properties": {
         "type": {
           "description": "Discriminant marker identifying the task.",
-          "const": "mark_timeout"
+          "enum": ["mark_timeout"]
         },
         "ts": {
           "description": "The timestamp the clock ticked at.",
@@ -43,7 +43,7 @@
       "properties": {
         "type": {
           "description": "Discriminant marker identifying the task.",
-          "const": "mark_missing"
+          "enum": ["mark_missing"]
         },
         "ts": {
           "description": "The timestamp the clock ticked at.",


### PR DESCRIPTION
This is due to the issue https://github.com/Tencent/rapidjson/issues/2314