### PR TITLE
feat: Add taskworker schema

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -74,6 +74,8 @@
 /topics/uptime-results.yaml                                    @getsentry/crons
 /topics/uptime-configs.yaml                                    @getsentry/crons
 
+/topics/task-worker.yaml                                       @getsentry/hybrid-cloud
+
 # Schemas
 /schemas/profile-metadata.v1.schema.json                       @getsentry/profiling
 /schemas/profile-functions.v1.schema.json                      @getsentry/profiling

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -74,6 +74,7 @@
 /topics/uptime-results.yaml                                    @getsentry/crons
 /topics/uptime-configs.yaml                                    @getsentry/crons
 
+# Topic for taskworker
 /topics/task-worker.yaml                                       @getsentry/hybrid-cloud
 
 # Schemas
@@ -89,6 +90,7 @@
 /schemas/monitors-clock-tasks.v1.schema.json                   @getsentry/crons
 /schemas/uptime-results.v1.schema.json                         @getsentry/crons
 /schemas/uptime-configs.v1.schema.json                         @getsentry/crons
+/schemas/taskworker.v1.schema.json                             @getsentry/hybrid-cloud
 
 # Examples
 /examples/group-attributes/                                    @getsentry/owners-snuba @getsentry/issues
@@ -107,6 +109,7 @@
 /examples/monitors-clock-tasks/                                @getsentry/crons
 /examples/uptime-results/                                      @getsentry/crons
 /examples/uptime-configs/                                      @getsentry/crons
+/examples/taskworker/                                          @getsentry/hybrid-cloud
 
 # Internal Snuba topics
 /topics/snuba-queries.yaml                                     @getsentry/owners-snuba

--- a/examples/taskworker/1/basic.json
+++ b/examples/taskworker/1/basic.json
@@ -1,0 +1,14 @@
+{
+  "id": "abcdef123",
+  "namespace": "issues",
+  "taskname": "issues.do_thing",
+  "parameters": "{\"args\": [], \"kwargs\": {}}",
+  "headers": {},
+  "received_at": 123456,
+  "deadline": null,
+  "retry": {
+    "attempts": 1,
+    "kind": "sentry.taskworker.retry.Retry",
+    "deadletter_after_attempt": 10
+  }
+}

--- a/schemas/taskworker.v1.schema.json
+++ b/schemas/taskworker.v1.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "RetryState": {
+      "title": "retry_state",
+      "description": "state from the task retry policy",
+      "type": "object",
+      "properties": {
+        "attempts": {
+          "description": "The number of attempts so far",
+          "type": "integer"
+        },
+        "kind": {
+          "description": "The kind of retry being done",
+          "type": "string"
+        },
+        "discard_after_attempt": {
+          "description": "The number of attempts after which a task is discarded",
+          "type": ["number", "null"]
+        },
+        "deadletter_after_attempt": {
+          "description": "The number of attempts after which a task is deadlettered",
+          "type": ["number", "null"]
+        }
+      },
+      "required": ["attempts", "kind"]
+    },
+    "TaskActivation": {
+      "description": "a single task activation",
+      "title": "task_activation",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "A GUID for the task. Used to update tasks",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "The task namespace",
+          "type": "string"
+        },
+        "taskname": {
+          "description": "The name of the task. This name is resolved within the worker",
+          "type": "string"
+        },
+        "parameters": {
+          "description": "An opaque parameter collection. Json serialized",
+          "type": "string"
+        },
+        "headers": {
+          "description": "a map of task headers",
+          "type": "object"
+        },
+        "received_at": {
+          "description": "The timestamp a task was stored in kafka",
+          "type": "number"
+        },
+        "deadline": {
+          "description": "The timestamp after which a task should not be executed",
+          "type": ["number", "null"]
+        },
+        "retry": {
+          "$ref": "#/definitions/RetryState"
+        }
+      },
+      "required": ["id", "namespace", "parameters", "headers", "received_at"]
+    }
+  }
+}

--- a/topics/task-worker.yaml
+++ b/topics/task-worker.yaml
@@ -1,0 +1,25 @@
+pipeline: taskworker
+description: |
+  Taskworker tasks to be executed
+services:
+  producers:
+    - getsentry/sentry
+  consumers:
+    - getsentry/sentry
+schemas:
+  - version: 1
+    compatibility_mode: none
+    # TODO(mark) protobuf support
+    type: json
+    resource: taskworker.v1.schema.json
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  message.timestamp.type: LogAppendTime
+  cleanup.policy: compact
+  # Tombstones are retained for a month
+  delete.retention.ms: "2629800000"
+  # Configurations are never dropped
+  retention.ms: "-1"
+

--- a/topics/task-worker.yaml
+++ b/topics/task-worker.yaml
@@ -22,4 +22,3 @@ topic_creation_config:
   delete.retention.ms: "2629800000"
   # Configurations are never dropped
   retention.ms: "-1"
-


### PR DESCRIPTION
The changes in getsentry/sentry#79742 are blocked because the `task-worker` topic does not have schema metadata.

While I would like this topic to contain protobuf messages, we lack tooling for that here at this time. As a temporary solution, I've added JSON schema for the task-worker topic, and will work on adding protobuf support separately.