### PR TITLE
feat(crons): Add monitors-incident-occurrences

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -69,6 +69,7 @@
 # Topics related to cron monitor tasks
 /topics/monitors-clock-tick.yaml                               @getsentry/crons
 /topics/monitors-clock-tasks.yaml                              @getsentry/crons
+/topics/monitors-incident-occurrences.yaml                     @getsentry/crons
 
 # Topics related to uptime
 /topics/uptime-results.yaml                                    @getsentry/crons

--- a/examples/monitors-incident-occurrences/1/example.json
+++ b/examples/monitors-incident-occurrences/1/example.json
@@ -1,0 +1,7 @@
+{
+  "clock_tick_ts": 1617895645,
+  "received_ts": 1617895650,
+  "failed_checkin_id": 123456,
+  "incident_id": 987654,
+  "previous_checkin_ids": [111222, 333444, 555666]
+}

--- a/schemas/monitors-incident-occurrences.v1.schema.json
+++ b/schemas/monitors-incident-occurrences.v1.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "monitors_incident_occurrence",
+  "$ref": "#/definitions/MonitorsIncidentOccurrence",
+  "definitions": {
+    "MonitorsIncidentOccurrence": {
+      "type": "object",
+      "title": "incident_occurrence",
+      "description": "A message containing the intent to create an issue occurrence for a monitor incident.",
+      "additionalProperties": false,
+      "properties": {
+        "clock_tick_ts": {
+          "description": "Timestamp of the clock-tick which triggered this occurrence.",
+          "type": "number"
+        },
+        "received_ts": {
+          "description": "Timestamp indicating when the offending check-in was recieved.",
+          "type": "number"
+        },
+        "failed_checkin_id": {
+          "description": "Database id of the offending check-in",
+          "type": "number"
+        },
+        "incident_id": {
+          "description": "Database id of the incident assoicated to this failure.",
+          "type": "number"
+        },
+        "previous_checkin_ids": {
+          "description": "Database ids of previously failed check-ins which led to the production of this occurrence.",
+          "type": "array",
+          "items": { "type": "number" }
+        }
+      },
+      "required": [
+        "clock_tick_ts",
+        "received_ts",
+        "failed_checkin_id",
+        "previous_checkin_ids"
+      ]
+    }
+  }
+}

--- a/topics/monitors-incident-occurrences.yaml
+++ b/topics/monitors-incident-occurrences.yaml
@@ -1,0 +1,18 @@
+pipeline: monitors
+description: stores data used to create issue occurrences for cron incidents
+services:
+  producers:
+    - getsentry/sentry
+  consumers:
+    - getsentry/sentry
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: json
+    resource: monitors-incident-occurrences.v1.schema.json
+    examples:
+      - monitors-incident-occurrences/1/
+topic_creation_config:
+  compression.type: lz4
+  message.timestamp.type: LogAppendTime
+  retention.ms: "86400000"


### PR DESCRIPTION
Part of https://github.com/getsentry/sentry/issues/79328

This creates the new topic necessary for delaying issue occurrences so that we can delay creation of notifications in the case where we detect an anomalous system incident.