### PR TITLE
ref(crons): Remove unused `volume_anomaly_result` from clock_tick

### DIFF
--- a/examples/monitors-clock-tick/1/example-volume-abnormal.json
+++ b/examples/monitors-clock-tick/1/example-volume-abnormal.json
@@ -1,4 +1,0 @@
-{
-  "ts": 1714072962,
-  "volume_anomaly_result": "abnormal"
-}

--- a/examples/monitors-clock-tick/1/example-volume-normal.json
+++ b/examples/monitors-clock-tick/1/example-volume-normal.json
@@ -1,4 +1,0 @@
-{
-  "ts": 1714072962,
-  "volume_anomaly_result": "normal"
-}

--- a/schemas/monitors-clock-tick.v1.schema.json
+++ b/schemas/monitors-clock-tick.v1.schema.json
@@ -12,11 +12,6 @@
         "ts": {
           "description": "The timestamp the clock ticked at.",
           "type": "number"
-        },
-        "volume_anomaly_result": {
-          "description": "The result of the volume anomaly detection for the minute that has been ticked past.",
-          "type": "string",
-          "enum": ["normal", "abnormal"]
         }
       },
       "required": ["ts"]


### PR DESCRIPTION
We'll no longer be passing this value through