### PR TITLE
ref(crons): Remove volume_anomaly_result from mark_missing task

### DIFF
--- a/examples/monitors-clock-tasks/1/mark_missing.json
+++ b/examples/monitors-clock-tasks/1/mark_missing.json
@@ -1,6 +1,5 @@
 {
   "type": "mark_missing",
   "ts": 1714072962,
-  "monitor_environment_id": 1,
-  "volume_anomaly_result": "normal"
+  "monitor_environment_id": 1
 }

--- a/examples/monitors-clock-tasks/1/mark_missing_abnormal.json
+++ b/examples/monitors-clock-tasks/1/mark_missing_abnormal.json
@@ -1,6 +1,0 @@
-{
-  "type": "mark_missing",
-  "ts": 1714072962,
-  "monitor_environment_id": 1,
-  "volume_anomaly_result": "abnormal"
-}

--- a/schemas/monitors-clock-tasks.v1.schema.json
+++ b/schemas/monitors-clock-tasks.v1.schema.json
@@ -77,11 +77,6 @@
           "description": "The timestamp the clock ticked at.",
           "type": "number"
         },
-        "volume_anomaly_result": {
-          "description": "The result of the volume anomaly detection for the minute that has been ticked past. Abnormal ticks cause misses to be recored as unknown.",
-          "type": "string",
-          "enum": ["normal", "abnormal"]
-        },
         "monitor_environment_id": {
           "description": "The monitor environment ID to generate a missed check-in for.",
           "type": "number"


### PR DESCRIPTION
We'll no longer be using this, similar to GH-349.

See https://github.com/getsentry/sentry/pull/80650