### PR TITLE
feat(uptime): add trace_sampling to kafka schema

### DIFF
--- a/schemas/uptime-configs.v1.schema.json
+++ b/schemas/uptime-configs.v1.schema.json
@@ -60,6 +60,10 @@
         "request_body": {
           "description": "Additional HTTP headers to send with the request",
           "type": "string"
+        },
+        "trace_sampling": {
+          "description": "Whether to allow for sampled trace spans for the request.",
+          "type": "boolean"
         }
       },
       "required": ["subscription_id", "interval_seconds", "timeout_ms", "url"]


### PR DESCRIPTION
- adds trace_sampling as an optional boolean field on our uptime config kafka schema. part of https://github.com/getsentry/team-uptime/issues/22