### PR TITLE
feat(uptime): new snuba-uptime-results topic

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -71,6 +71,7 @@
 /topics/monitors-incident-occurrences.yaml                     @getsentry/crons
 
 # Topics related to uptime
+/topics/snuba-uptime-results.yaml                              @getsentry/crons
 /topics/uptime-results.yaml                                    @getsentry/crons
 /topics/uptime-configs.yaml                                    @getsentry/crons
 
@@ -89,6 +90,7 @@
 /schemas/monitors-clock-tasks.v1.schema.json                   @getsentry/crons
 /schemas/uptime-results.v1.schema.json                         @getsentry/crons
 /schemas/uptime-configs.v1.schema.json                         @getsentry/crons
+/schemas/snuba-uptime-results.v1.schema.json                   @getsentry/crons
 /schemas/taskworker.v1.schema.json                             @getsentry/hybrid-cloud
 
 # Examples
@@ -107,6 +109,7 @@
 /examples/monitors-clock-tasks/                                @getsentry/crons
 /examples/uptime-results/                                      @getsentry/crons
 /examples/uptime-configs/                                      @getsentry/crons
+/examples/snuba-uptime-results/                                @getsentry/crons
 /examples/taskworker/                                          @getsentry/taskworker
 
 # Internal Snuba topics

--- a/examples/snuba-uptime-results/1/failure.json
+++ b/examples/snuba-uptime-results/1/failure.json
@@ -1,0 +1,22 @@
+{
+  "guid": "54afc7ed9c53491481919c931f75bae1",
+  "subscription_id": "5421b5df80744113a6b57014f01a3a42",
+  "status": "failure",
+  "status_reason": {
+    "type": "dns_error",
+    "description": "Unable to resolve hostname example.xyz"
+  },
+  "trace_id": "947efba02dac463b9c1d886a44bafc94",
+  "span_id": "58e84098e63f42e1",
+  "scheduled_check_time_ms": 1717614062978,
+  "actual_check_time_ms": 1717614068008,
+  "duration_ms": 100,
+  "request_info": {
+    "request_type": "HEAD",
+    "http_status_code": 500
+  },
+  "organization_id": 123,
+  "project_id": 456,
+  "retention_days": 90,
+  "region_slug": "us-east-1"
+}

--- a/examples/snuba-uptime-results/1/succeess.json
+++ b/examples/snuba-uptime-results/1/succeess.json
@@ -1,0 +1,19 @@
+{
+  "guid": "54afc7ed9c53491481919c931f75bae1",
+  "subscription_id": "5421b5df80744113a6b57014f01a3a42",
+  "status": "success",
+  "status_reason": null,
+  "trace_id": "947efba02dac463b9c1d886a44bafc94",
+  "span_id": "58e84098e63f42e1",
+  "scheduled_check_time_ms": 1717614062978,
+  "actual_check_time_ms": 1717614068008,
+  "duration_ms": 50,
+  "request_info": {
+    "request_type": "HEAD",
+    "http_status_code": 200
+  },
+  "organization_id": 123,
+  "project_id": 456,
+  "retention_days": 90,
+  "region_slug": "us-east-1"
+}

--- a/examples/snuba-uptime-results/1/timeout.json
+++ b/examples/snuba-uptime-results/1/timeout.json
@@ -1,0 +1,22 @@
+{
+  "guid": "54afc7ed9c53491481919c931f75bae1",
+  "subscription_id": "5421b5df80744113a6b57014f01a3a42",
+  "status": "failure",
+  "status_reason": {
+    "type": "timeout",
+    "description": "Check timed out"
+  },
+  "trace_id": "947efba02dac463b9c1d886a44bafc94",
+  "span_id": "58e84098e63f42e1",
+  "scheduled_check_time_ms": 1717614062978,
+  "actual_check_time_ms": 1717614068008,
+  "duration_ms": 100,
+  "request_info": {
+    "request_type": "HEAD",
+    "http_status_code": null
+  },
+  "organization_id": 123,
+  "project_id": 456,
+  "retention_days": 90,
+  "region_slug": "us-east-1"
+}

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -246,6 +246,7 @@ mod tests {
         // Did not error
         get_schema("snuba-queries", Some(1)).unwrap();
         get_schema("transactions", Some(1)).unwrap();
+        get_schema("snuba-uptime-results", Some(1)).unwrap();
     }
 
     fn validate_schema(schema_name: &str) {
@@ -267,5 +268,6 @@ mod tests {
     fn test_validate() {
         validate_schema("snuba-queries");
         validate_schema("uptime-results");
+        validate_schema("snuba-uptime-results");
     }
 }

--- a/schemas/snuba-uptime-results.v1.schema.json
+++ b/schemas/snuba-uptime-results.v1.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "snuba_uptime_result",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "file://uptime-results.v1.schema.json#/definitions/CheckResult"
+    }
+  ],
+  "properties": {
+    "organization_id": {
+      "type": "integer",
+      "description": "The organization ID associated with this check",
+      "minimum": 0
+    },
+    "project_id": {
+      "type": "integer",
+      "description": "The project ID associated with this check",
+      "minimum": 0
+    },
+    "retention_days": {
+      "type": "integer",
+      "description": "Number of days to retain this data",
+      "minimum": 0,
+      "maximum": 65535
+    },
+    "region_slug": {
+      "type": ["string", "null"],
+      "description": "The region identifier where this check was performed"
+    }
+  },
+  "required": ["organization_id", "project_id", "retention_days"]
+}

--- a/topics/snuba-uptime-results.yaml
+++ b/topics/snuba-uptime-results.yaml
@@ -1,0 +1,18 @@
+pipeline: uptime
+description: uptime check results for snuba
+services:
+  producers:
+    - getsentry/sentry
+  consumers:
+    - getsentry/snuba
+schemas:
+  - version: 1
+    compatibility_mode: backward
+    type: json
+    resource: snuba-uptime-results.v1.schema.json
+    examples:
+      - snuba-uptime-results/1/
+topic_creation_config:
+  compression.type: lz4
+  message.timestamp.type: LogAppendTime
+  retention.ms: "86400000"


### PR DESCRIPTION
I wanted to avoid duplication in https://github.com/getsentry/sentry-kafka-schemas/pull/359, so I wrote https://github.com/getsentry/sentry-kafka-schemas/pull/360 to allow us to reference other schemas.