### PR TITLE
feat(uptime): Include region in uptime results

### DIFF
--- a/schemas/uptime-results.v1.schema.json
+++ b/schemas/uptime-results.v1.schema.json
@@ -107,6 +107,10 @@
               "type": "null"
             }
           ]
+        },
+        "region": {
+          "description": "The region that this check was performed in",
+          "type": "string"
         }
       },
       "required": [


### PR DESCRIPTION
Add `region` to uptime results, so that we're able to track where this result came from.