### PR TITLE
Improve support for protocol buffer topics in rust library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Checkout code
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
       - uses: actions/cache@v3
         name: Restore build cache
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Checkout code
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
       - uses: actions/cache@v3
         name: Restore build cache
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ required-features = ["type_generation"]
 
 [features]
 default = ["type_generation"]
-type_generation = ["prettyplease", "schemars", "syn", "typify"]
+type_generation = ["prettyplease", "schemars", "syn", "typify", "sentry_protos", "prost"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -40,8 +40,6 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 jsonschema = { version = "0.18.1", default-features = false }
 thiserror = "1.0.49"
-sentry_protos = ">=0.1.39"
-prost = "0.13"
 
 # redeclare all build-dependencies here so that the build.rs can be used
 # standalone to view types
@@ -49,6 +47,8 @@ prettyplease = { version = "0.2.4", optional = true }
 schemars = { version = "0.8.0", optional = true }
 syn = { version = "2.0.11", optional = true }
 typify = { version = "0.0.16", optional = true }
+sentry_protos = { version = ">=0.1.39", optional = true }
+prost = { version = "0.13", optional = true }
 url = "2.5.4"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 jsonschema = { version = "0.18.1", default-features = false }
 thiserror = "1.0.49"
+sentry_protos = ">=0.1.39"
+prost = "0.13"
 
 # redeclare all build-dependencies here so that the build.rs can be used
 # standalone to view types
@@ -52,6 +54,10 @@ url = "2.5.4"
 [build-dependencies]
 prettyplease = { version = "0.2.4", optional = true }
 schemars = { version = "0.8.0", optional = true }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.9"
 syn = { version = "2.0.11", optional = true }
 typify = { version = "0.0.16", optional = true }
+sentry_protos = ">=0.1.39"
+prost = "0.13"

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
 use serde::Deserialize;
+use std::path::Path;
 
 #[cfg(feature = "type_generation")]
 use {
@@ -128,7 +128,6 @@ fn mangle_resource_name(resource: &str) -> String {
     // generated rust code does not.
     let parts: Vec<&str> = resource
         .split(".")
-        .into_iter()
         .filter(|part| !part.ends_with("_pb2"))
         .collect();
     parts.join("::")
@@ -168,17 +167,21 @@ fn generate_proto_shim() -> String {
         writeln!(tuples, "    (\"{resource}\", |input: &[u8]| {{").unwrap();
         writeln!(tuples, "        let parsed = {struct_name}::decode(input);").unwrap();
         writeln!(tuples, "        match parsed {{").unwrap();
-        writeln!(tuples, "            Ok(value) => Ok(Box::new(value) as Box<dyn Any>),").unwrap();
+        writeln!(
+            tuples,
+            "            Ok(value) => Ok(Box::new(value) as Box<dyn Any>),"
+        )
+        .unwrap();
         writeln!(tuples, "            Err(err) => Err(err),").unwrap();
         writeln!(tuples, "        }}").unwrap();
         writeln!(tuples, "    }}),").unwrap();
     }
     let mut code = String::new();
-    writeln!(code, "").unwrap();
-    writeln!(code, "").unwrap();
+    writeln!(code).unwrap();
+    writeln!(code).unwrap();
     writeln!(code, "// Imports for protobuf topic schemas").unwrap();
     code.push_str(&imports);
-    writeln!(code, "").unwrap();
+    writeln!(code).unwrap();
     writeln!(code, "pub const PROTOS: &[(&str, fn(input: &[u8]) -> Result<Box<dyn Any>, prost::DecodeError>)] = &[").unwrap();
     code.push_str(&tuples);
     writeln!(code, "];").unwrap();
@@ -216,7 +219,8 @@ fn main() {
     let module_code = {
         #[cfg(feature = "type_generation")]
         {
-            let mut code = generate_schema("schemas/ingest-metrics.v1.schema.json", "ingest_metrics_v1");
+            let mut code =
+                generate_schema("schemas/ingest-metrics.v1.schema.json", "ingest_metrics_v1");
             let proto_code = generate_proto_shim();
             code.push_str(&proto_code);
 

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -174,8 +174,11 @@ fn generate_proto_shim() -> String {
         writeln!(tuples, "    }}),").unwrap();
     }
     let mut code = String::new();
+    writeln!(code, "").unwrap();
+    writeln!(code, "").unwrap();
     writeln!(code, "// Imports for protobuf topic schemas").unwrap();
     code.push_str(&imports);
+    writeln!(code, "").unwrap();
     writeln!(code, "pub const PROTOS: &[(&str, fn(input: &[u8]) -> Result<Box<dyn Any>, prost::DecodeError>)] = &[").unwrap();
     code.push_str(&tuples);
     writeln!(code, "];").unwrap();

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -290,7 +290,7 @@ mod tests {
         assert_eq!(schema.version, 1);
         assert_eq!(schema.schema_type, SchemaType::Protobuf);
         assert_eq!(schema.examples.len(), 1);
-        assert!(schema.schema.starts_with("sentry_protos"));
+        assert!(schema.schema.starts_with("sentry_protos.sentry.v1"));
 
         // Did not error
         get_schema("snuba-queries", Some(1)).unwrap();
@@ -308,6 +308,7 @@ mod tests {
         let parsed = result.unwrap();
         let contents = parsed.downcast::<sentry_protos::sentry::v1::TaskActivation>().unwrap();
         assert_eq!(contents.id, "abc123");
+        assert_eq!(contents.taskname, "tests.do_things");
     }
 
     fn validate_schema(schema_name: &str) {

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1,8 +1,8 @@
 use jsonschema::{JSONSchema, SchemaResolver, SchemaResolverError};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::sync::Arc;
 use std::any::Any;
+use std::sync::Arc;
 use thiserror::Error;
 use url::Url;
 // This file is supposed to be auto-generated via rust/build.rs
@@ -118,8 +118,8 @@ impl Schema {
         if self.schema_type != SchemaType::Protobuf {
             return Err(SchemaError::InvalidType);
         }
-        let proto_factory = find_entry( schema_types::PROTOS, self.schema)
-            .ok_or(SchemaError::InvalidSchema)?;
+        let proto_factory =
+            find_entry(schema_types::PROTOS, self.schema).ok_or(SchemaError::InvalidSchema)?;
         let parse_result = proto_factory(input);
         if let Ok(parsed) = parse_result {
             return Ok(parsed);
@@ -257,7 +257,6 @@ pub fn get_schema(topic: &str, version: Option<u16>) -> Result<Schema, SchemaErr
             examples,
         })
     }
-
 }
 
 #[cfg(test)]
@@ -306,7 +305,9 @@ mod tests {
         assert!(result.is_ok());
 
         let parsed = result.unwrap();
-        let contents = parsed.downcast::<sentry_protos::sentry::v1::TaskActivation>().unwrap();
+        let contents = parsed
+            .downcast::<sentry_protos::sentry::v1::TaskActivation>()
+            .unwrap();
         assert_eq!(contents.id, "abc123");
         assert_eq!(contents.taskname, "tests.do_things");
     }


### PR DESCRIPTION
When adding support for protocol buffer support for topic schema in #344 I only implemented python support. These changes add similar support for the rust library.

Because we effectively need to look up protobuf generated code at runtime, I expanded the scope of `build.rs` to generate `PROTOS`, which is similar to `EXAMPLES` and `TOPICS`. In order to appease the compiler, I needed to use `Box<dyn Any>` and `.downcast` into the specific structure that the consuming application needs. Obviously this parse/validate logic requires having `sentry-protos` available expanding the dependencies of this project, which could spill into consuming applications as well.