### PR TITLE
Remove date range for LICENSE

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -6,7 +6,7 @@ FSL-1.1-Apache-2.0
 
 ## Notice
 
-Copyright 2022-2024 Functional Software, Inc. dba Sentry
+Copyright 2022 Functional Software, Inc. dba Sentry
 
 ## Terms and Conditions
 


### PR DESCRIPTION
In our internal [Open Source Legal Policy](https://www.notion.so/sentry/Open-Source-Legal-Policy-ac4885d265cb4d7898a01c060b061e42), we decided that licenses don't require a data range. This also has the advantage of not updating the date range yearly.

#skip-changelog

cc @gavin-zee