### PR TITLE
Creating the events backlog topic

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,6 +22,7 @@
 /topics/ingest-feedback-events-dlq.yaml                        @getsentry/owners-snuba @getsentry/replay-backend
 
 # BLQs for ingest topics
+/topics/ingest-events-backlog.yaml			       @getsentry/ops
 /topics/ingest-transactions-backlog.yaml                       @getsentry/ops
 
 # Topics consumed by Snuba

--- a/topics/ingest-events-backlog.yaml
+++ b/topics/ingest-events-backlog.yaml
@@ -1,0 +1,17 @@
+Pipeline: errors
+description: Backlog queue for ingest-events
+services:
+  producers:
+    - getsentry/sentry
+  consumers: []
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: msgpack
+    resource: ingest-events.v1.schema.json
+    examples:
+      - ingest-events/1/
+topic_creation_config:
+  compression.type: lz4
+  retention.ms: "604800000" # 7 days
+  max.message.bytes: "10000000"

--- a/topics/ingest-events-backlog.yaml
+++ b/topics/ingest-events-backlog.yaml
@@ -3,7 +3,8 @@ description: Backlog queue for ingest-events
 services:
   producers:
     - getsentry/sentry
-  consumers: []
+  consumers:
+    - getsentry/sentry
 schemas:
   - version: 1
     compatibility_mode: none
@@ -13,5 +14,5 @@ schemas:
       - ingest-events/1/
 topic_creation_config:
   compression.type: lz4
-  retention.ms: "604800000" # 7 days
+  retention.ms: "86400000"
   max.message.bytes: "10000000"

--- a/topics/ingest-transactions-backlog.yaml
+++ b/topics/ingest-transactions-backlog.yaml
@@ -3,7 +3,8 @@ description: Backlog queue for ingest-transactions
 services:
   producers:
     - getsentry/sentry
-  consumers: []
+  consumers:
+    - getsentry/sentry
 schemas:
   - version: 1
     compatibility_mode: none
@@ -13,5 +14,5 @@ schemas:
       - ingest-transactions/1/
 topic_creation_config:
   compression.type: lz4
-  retention.ms: "604800000" # 7 days
+  retention.ms: "86400000"
   max.message.bytes: "10000000"


### PR DESCRIPTION
This creates the errors/events backlog topic for kafka router. This does so in all regions. 