### PR TITLE
fix incorrect pipeline annotations

### DIFF
--- a/topics/snuba-dead-letter-generic-metrics.yaml
+++ b/topics/snuba-dead-letter-generic-metrics.yaml
@@ -1,4 +1,4 @@
-pipeline: errors
+pipeline: generic-metrics
 description: DLQ for snuba-generic-metrics
 services:
   producers:

--- a/topics/snuba-dead-letter-group-attributes.yaml
+++ b/topics/snuba-dead-letter-group-attributes.yaml
@@ -1,4 +1,3 @@
-pipeline: errors
 description: DLQ for group-attributes
 services:
   producers:

--- a/topics/snuba-dead-letter-metrics.yaml
+++ b/topics/snuba-dead-letter-metrics.yaml
@@ -1,4 +1,4 @@
-pipeline: errors
+pipeline: release-health
 description: DLQ for snuba-metrics
 services:
   producers:

--- a/topics/snuba-dead-letter-querylog.yaml
+++ b/topics/snuba-dead-letter-querylog.yaml
@@ -1,4 +1,3 @@
-pipeline: errors
 description: DLQ for snuba-queries
 services:
   producers:

--- a/topics/snuba-dead-letter-replays.yaml
+++ b/topics/snuba-dead-letter-replays.yaml
@@ -1,4 +1,4 @@
-pipeline: errors
+pipeline: replays
 description: DLQ for ingest-replay-events
 services:
   producers:


### PR DESCRIPTION
we found these bugs when using this data to generate initial cluster assignments for itty-bitty