### PR TITLE
feat: Introduce ingest-spans

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,6 +11,7 @@
 /topics/ingest-feedback-events.yaml                            @getsentry/owners-snuba @getsentry/replay-backend
 /topics/ingest-monitors.yaml                                   @getsentry/crons
 /topics/ingest-occurrences.yaml                                @getsentry/issues
+/topics/ingest-spans.yaml                                      @getsentry/ingest
 /topics/profiles.yaml                                          @getsentry/profiling
 
 # DLQs for ingest topics
@@ -89,6 +90,7 @@
 /schemas/snuba-profile-chunks.v1.schema.json                   @getsentry/profiling
 /schemas/group-attributes.v1.schema.json                       @getsentry/owners-snuba @getsentry/issues
 /schemas/snuba-spans.v1.schema.json                            @getsentry/performance
+/schemas/ingest-spans.v1.schema.json                           @getsentry/ingest
 /schemas/buffered-segments.v1.schema.json                      @getsentry/owners-snuba @getsentry/performance
 /schemas/ingest-monitors.v1.schema.json                        @getsentry/crons
 /schemas/monitors-clock-tick.v1.schema.json                    @getsentry/crons
@@ -103,7 +105,7 @@
 /examples/group-attributes/                                    @getsentry/owners-snuba @getsentry/issues
 /examples/profile-metadata/                                    @getsentry/profiling
 /examples/profile-functions/                                   @getsentry/profiling
-/examples/snuba-spans/                                         @getsentry/profiling
+/examples/ingest-spans/                                        @getsentry/ingest
 /examples/profile-metadata/                                    @getsentry/profiling
 /examples/profile-functions/                                   @getsentry/profiling
 /examples/snuba-profile-chunks/                                @getsentry/profiling

--- a/examples/ingest-spans/1/basic_span.json
+++ b/examples/ingest-spans/1/basic_span.json
@@ -1,0 +1,43 @@
+{
+  "event_id": "dcc403b73ef548648188bbfa6012e9dc",
+  "organization_id": 69,
+  "project_id": 1,
+  "trace_id": "deadbeefdeadbeefdeadbeefdeadbeef",
+  "span_id": "deadbeefdeadbeef",
+  "parent_span_id": "deadbeefdeadbeef",
+  "segment_id": "deadbeefdeadbeef",
+  "duration_ms": 1000,
+  "exclusive_time_ms": 1000,
+  "is_segment": false,
+  "profile_id": "deadbeefdeadbeefdeadbeefdeadbeef",
+  "received": 1715868485.381,
+  "retention_days": 90,
+  "start_timestamp_ms": 1715868485371,
+  "start_timestamp_precise": 1715868485.370551,
+  "end_timestamp_precise": 1715868486.370551,
+  "tags": {
+    "tag1": "value1",
+    "tag2": "123",
+    "tag3": "True"
+  },
+  "sentry_tags": {
+    "http.method": "GET",
+    "action": "GET",
+    "domain": "targetdomain.tld:targetport",
+    "module": "http",
+    "group": "deadbeefdeadbeef",
+    "status": "ok",
+    "system": "python",
+    "status_code": "200",
+    "transaction": "/organizations/:orgId/issues/",
+    "transaction.op": "navigation",
+    "op": "http.client",
+    "transaction.method": "GET"
+  },
+  "measurements": {
+    "http.response_content_length": {
+      "value": 100.0,
+      "unit": "byte"
+    }
+  }
+}

--- a/schemas/ingest-spans.v1.schema.json
+++ b/schemas/ingest-spans.v1.schema.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "spans_stream_message",
+  "$ref": "#/definitions/SpanEvent",
+  "definitions": {
+    "SpanEvent": {
+      "type": "object",
+      "title": "span_event",
+      "additionalProperties": true,
+      "properties": {
+        "event_id": {
+          "$ref": "#/definitions/UUID"
+        },
+        "organization_id": {
+          "$ref": "#/definitions/UInt"
+        },
+        "project_id": {
+          "$ref": "#/definitions/UInt"
+        },
+        "trace_id": {
+          "$ref": "#/definitions/UUID",
+          "description": "The trace ID is a unique identifier for a trace. It is a 16 byte hexadecimal string."
+        },
+        "span_id": {
+          "type": "string",
+          "description": "The span ID is a unique identifier for a span within a trace. It is an 8 byte hexadecimal string."
+        },
+        "parent_span_id": {
+          "type": "string",
+          "description": "The parent span ID is the ID of the span that caused this span. It is an 8 byte hexadecimal string."
+        },
+        "segment_id": {
+          "type": "string",
+          "description": "The segment ID is a unique identifier for a segment within a trace. It is an 8 byte hexadecimal string."
+        },
+        "profile_id": {
+          "$ref": "#/definitions/UUID",
+          "description": "The profile ID. It is an 16 byte hexadecimal string."
+        },
+        "is_segment": {
+          "type": "boolean",
+          "description": "Whether this span is a segment or not."
+        },
+        "start_timestamp_ms": {
+          "$ref": "#/definitions/UInt",
+          "description": "The start timestamp of the span in milliseconds since epoch."
+        },
+        "start_timestamp_precise": {
+          "$ref": "#/definitions/PositiveFloat",
+          "description": "UNIX timestamp in seconds with fractional part up to microsecond precision."
+        },
+        "end_timestamp_precise": {
+          "$ref": "#/definitions/PositiveFloat",
+          "description": "UNIX timestamp in seconds with fractional part up to microsecond precision."
+        },
+        "duration_ms": {
+          "$ref": "#/definitions/UInt32",
+          "description": "The duration of the span in milliseconds."
+        },
+        "exclusive_time_ms": {
+          "$ref": "#/definitions/PositiveFloat",
+          "description": "The exclusive time of the span in milliseconds."
+        },
+        "retention_days": {
+          "$ref": "#/definitions/UInt16"
+        },
+        "received": {
+          "$ref": "#/definitions/PositiveFloat",
+          "description": "Unix timestamp when the span was received by Sentry."
+        },
+        "description": {
+          "type": "string"
+        },
+        "tags": {
+          "description": " Manual key/value tag pairs.",
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/TagValue"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sentry_tags": {
+          "$ref": "#/definitions/SentryExtractedTags"
+        },
+        "measurements": {
+          "$ref": "#/definitions/Measurements"
+        },
+        "data": {
+          "$ref": "#/definitions/Data"
+        },
+        "_metrics_summary": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MetricsSummary"
+          }
+        }
+      },
+      "required": [
+        "duration_ms",
+        "exclusive_time_ms",
+        "is_segment",
+        "project_id",
+        "organization_id",
+        "received",
+        "retention_days",
+        "span_id",
+        "start_timestamp_ms",
+        "start_timestamp_precise",
+        "end_timestamp_precise",
+        "trace_id"
+      ]
+    },
+    "SentryExtractedTags": {
+      "description": "Tags extracted by sentry. These are kept separate from customer tags",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "http.method": {
+              "type": "string"
+            },
+            "action": {
+              "type": "string"
+            },
+            "domain": {
+              "type": "string"
+            },
+            "module": {
+              "type": "string"
+            },
+            "group": {
+              "type": "string"
+            },
+            "system": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "status_code": {
+              "type": "string"
+            },
+            "transaction": {
+              "type": "string"
+            },
+            "transaction.op": {
+              "type": "string"
+            },
+            "op": {
+              "type": "string"
+            },
+            "transaction.method": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "TagValue": {
+      "type": "string"
+    },
+    "UUID": {
+      "type": "string",
+      "minLength": 32,
+      "maxLength": 36
+    },
+    "UInt16": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 65535
+    },
+    "UInt32": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 4294967295
+    },
+    "UInt": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "PositiveFloat": {
+      "type": "number",
+      "minimum": 0
+    },
+    "Measurements": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/MeasurementValue"
+      }
+    },
+    "Data": {
+      "type": "object"
+    },
+    "MeasurementValue": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string"
+        }
+      },
+      "required": ["value"]
+    },
+    "MetricsSummary": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/MetricSummaryValue"
+      }
+    },
+    "MetricSummaryValue": {
+      "type": "object",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "number"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/topics/ingest-spans.yaml
+++ b/topics/ingest-spans.yaml
@@ -1,0 +1,19 @@
+pipeline: spans
+description: Pre-buffering spans from Relay
+services:
+  producers:
+    - getsentry/relay
+  consumers:
+    - getsentry/sentry
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: json
+    resource: ingest-spans.v1.schema.json
+    examples:
+      - ingest-spans/1/
+topic_creation_config:
+  compression.type: lz4
+  retention.ms: "86400000"
+  max.message.bytes: "10000000"
+  message.timestamp.type: LogAppendTime


### PR DESCRIPTION
Introduces the `ingest-spans` topic and schema, which is the ingest counterpart
to `snuba-spans`. It will receive unbuffered spans directly from Relay to be
consumed by the trace buffer in Sentry.

Initially, this is a clone of the `snuba-spans` schema. Over time, the
definition will diverge, with `ingest-spans` having fewer attributes that are
not available before spans have been buffered.

This topic will not be used in production until further notice.

See https://github.com/getsentry/sentry/pull/86201