### PR TITLE
fix(spans): Align the spans topics with reality

### DIFF
--- a/examples/snuba-spans/1/basic_span.json
+++ b/examples/snuba-spans/1/basic_span.json
@@ -39,39 +39,5 @@
       "value": 100.0,
       "unit": "byte"
     }
-  },
-  "_metrics_summary": {
-    "c:sentry.events.outcomes@none": [
-      {
-        "count": 1,
-        "max": 1.0,
-        "min": 1.0,
-        "sum": 1.0,
-        "tags": {
-          "category": "error",
-          "environment": "unknown",
-          "event_type": "error",
-          "outcome": "accepted",
-          "release": "backend@2af74c237fbd61489a1ccc46650f4f85befaf8b8",
-          "topic": "outcomes-billing",
-          "transaction": "sentry.tasks.store.save_event"
-        }
-      }
-    ],
-    "c:sentry.events.post_save.normalize.errors@none": [
-      {
-        "count": 1,
-        "max": 0.0,
-        "min": 0.0,
-        "sum": 0.0,
-        "tags": {
-          "environment": "unknown",
-          "event_type": "error",
-          "from_relay": "False",
-          "release": "backend@2af74c237fbd61489a1ccc46650f4f85befaf8b8",
-          "transaction": "sentry.tasks.store.save_event"
-        }
-      }
-    ]
   }
 }

--- a/schemas/buffered-segments.v1.schema.json
+++ b/schemas/buffered-segments.v1.schema.json
@@ -5,21 +5,22 @@
   "additionalProperties": true,
   "properties": {
     "spans": {
-      "$ref": "#/definitions/Spans"
+      "$ref": "#/definitions/SegmentSpans"
     }
   },
   "required": ["spans"],
   "definitions": {
-    "Spans": {
+    "SegmentSpans": {
       "type": "array",
       "minItems": 1,
       "items": {
-        "$ref": "#/definitions/Span"
+        "$ref": "#/definitions/SegmentSpan"
       }
     },
-    "Span": {
+    "SegmentSpan": {
       "type": "object",
       "additionalProperties": true,
+      "title": "segment_span",
       "properties": {
         "event_id": {
           "$ref": "#/definitions/UUID"
@@ -39,11 +40,11 @@
           "description": "The span ID is a unique identifier for a span within a trace. It is an 8 byte hexadecimal string."
         },
         "parent_span_id": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "The parent span ID is the ID of the span that caused this span. It is an 8 byte hexadecimal string."
         },
         "segment_id": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "The segment ID is a unique identifier for a segment within a trace. It is an 8 byte hexadecimal string."
         },
         "profile_id": {
@@ -61,10 +62,6 @@
         "duration_ms": {
           "$ref": "#/definitions/UInt32",
           "description": "The duration of the span in milliseconds."
-        },
-        "exclusive_time_ms": {
-          "$ref": "#/definitions/PositiveFloat",
-          "description": "The exclusive time of the span in milliseconds."
         },
         "retention_days": {
           "$ref": "#/definitions/UInt16"
@@ -95,17 +92,10 @@
         },
         "measurements": {
           "$ref": "#/definitions/Measurements"
-        },
-        "_metrics_summary": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/MetricsSummary"
-          }
         }
       },
       "required": [
         "duration_ms",
-        "exclusive_time_ms",
         "is_segment",
         "project_id",
         "received",
@@ -205,35 +195,6 @@
         }
       },
       "required": ["value"]
-    },
-    "MetricsSummary": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/MetricSummaryValue"
-      }
-    },
-    "MetricSummaryValue": {
-      "type": "object",
-      "properties": {
-        "min": {
-          "type": "number"
-        },
-        "max": {
-          "type": "number"
-        },
-        "sum": {
-          "type": "number"
-        },
-        "count": {
-          "type": "number"
-        },
-        "tags": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
     }
   }
 }

--- a/schemas/ingest-spans.v1.schema.json
+++ b/schemas/ingest-spans.v1.schema.json
@@ -26,20 +26,12 @@
           "description": "The span ID is a unique identifier for a span within a trace. It is an 8 byte hexadecimal string."
         },
         "parent_span_id": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "The parent span ID is the ID of the span that caused this span. It is an 8 byte hexadecimal string."
-        },
-        "segment_id": {
-          "type": "string",
-          "description": "The segment ID is a unique identifier for a segment within a trace. It is an 8 byte hexadecimal string."
         },
         "profile_id": {
           "$ref": "#/definitions/UUID",
           "description": "The profile ID. It is an 16 byte hexadecimal string."
-        },
-        "is_segment": {
-          "type": "boolean",
-          "description": "Whether this span is a segment or not."
         },
         "start_timestamp_ms": {
           "$ref": "#/definitions/UInt",
@@ -56,10 +48,6 @@
         "duration_ms": {
           "$ref": "#/definitions/UInt32",
           "description": "The duration of the span in milliseconds."
-        },
-        "exclusive_time_ms": {
-          "$ref": "#/definitions/PositiveFloat",
-          "description": "The exclusive time of the span in milliseconds."
         },
         "retention_days": {
           "$ref": "#/definitions/UInt16"
@@ -93,18 +81,10 @@
         },
         "data": {
           "$ref": "#/definitions/Data"
-        },
-        "_metrics_summary": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/MetricsSummary"
-          }
         }
       },
       "required": [
         "duration_ms",
-        "exclusive_time_ms",
-        "is_segment",
         "project_id",
         "organization_id",
         "received",
@@ -209,35 +189,6 @@
         }
       },
       "required": ["value"]
-    },
-    "MetricsSummary": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/MetricSummaryValue"
-      }
-    },
-    "MetricSummaryValue": {
-      "type": "object",
-      "properties": {
-        "min": {
-          "type": "number"
-        },
-        "max": {
-          "type": "number"
-        },
-        "sum": {
-          "type": "number"
-        },
-        "count": {
-          "type": "number"
-        },
-        "tags": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
     }
   }
 }

--- a/schemas/snuba-spans.v1.schema.json
+++ b/schemas/snuba-spans.v1.schema.json
@@ -26,11 +26,11 @@
           "description": "The span ID is a unique identifier for a span within a trace. It is an 8 byte hexadecimal string."
         },
         "parent_span_id": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "The parent span ID is the ID of the span that caused this span. It is an 8 byte hexadecimal string."
         },
         "segment_id": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "The segment ID is a unique identifier for a segment within a trace. It is an 8 byte hexadecimal string."
         },
         "profile_id": {
@@ -93,12 +93,6 @@
         },
         "data": {
           "$ref": "#/definitions/Data"
-        },
-        "_metrics_summary": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/MetricsSummary"
-          }
         }
       },
       "required": [
@@ -209,35 +203,6 @@
         }
       },
       "required": ["value"]
-    },
-    "MetricsSummary": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/MetricSummaryValue"
-      }
-    },
-    "MetricSummaryValue": {
-      "type": "object",
-      "properties": {
-        "min": {
-          "type": "number"
-        },
-        "max": {
-          "type": "number"
-        },
-        "sum": {
-          "type": "number"
-        },
-        "count": {
-          "type": "number"
-        },
-        "tags": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
Various fixes to the `ingest-spans`, `buffered-segments`, and `snuba-spans`
schema definitions:

- Remove `_metrics_summary`, as this is no longer produced and supported
- Make `parent_span_id` and `segment_id` optional everywhere
- Remove `exclusive_time_ms` from `ingest-spans` and `buffered-segments`
- Remove `is_segment` and `segment_id` from `ingest-spans`

Also exposes `SegmentSpan` as named type from `buffered-segments` for the consumer

