### PR TITLE
chore(taskworker): Temporarily add task-worker

### DIFF
--- a/topics/task-worker.yaml
+++ b/topics/task-worker.yaml
@@ -1,0 +1,23 @@
+pipeline: taskworker
+description: |
+  Taskworker tasks to be executed
+services:
+  producers:
+    - getsentry/sentry
+  consumers:
+    - getsentry/taskbroker
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.sentry.v1.taskworker_pb2.TaskActivation
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  message.timestamp.type: LogAppendTime
+  cleanup.policy: compact
+  # Tombstones are retained for a month
+  delete.retention.ms: "2629800000"
+  # Configurations are never dropped
+  retention.ms: "-1"


### PR DESCRIPTION
In order to remove the logical `task-worker` topic name in sentry and getsentry, this file needs to exist. Temporarily add this configuration.