### PR TITLE
feat(snuba-spans): add `kind` field

### DIFF
--- a/examples/snuba-spans/1/basic_span.json
+++ b/examples/snuba-spans/1/basic_span.json
@@ -9,6 +9,7 @@
   "duration_ms": 1000,
   "exclusive_time_ms": 1000,
   "is_segment": false,
+  "kind": "internal",
   "profile_id": "deadbeefdeadbeefdeadbeefdeadbeef",
   "received": 1715868485.381,
   "retention_days": 90,

--- a/schemas/snuba-spans.v1.schema.json
+++ b/schemas/snuba-spans.v1.schema.json
@@ -41,6 +41,10 @@
           "type": "boolean",
           "description": "Whether this span is a segment or not."
         },
+        "kind": {
+          "type": "string",
+          "description": "The span kind (one of internal, server, client, producer or consumer)."
+        },
         "start_timestamp_ms": {
           "$ref": "#/definitions/UInt",
           "description": "The start timestamp of the span in milliseconds since epoch."


### PR DESCRIPTION
Relay started sending this property in https://github.com/getsentry/relay/pull/4540. Align the schema so that Snuba's CI recognizes the field (see https://github.com/getsentry/snuba/actions/runs/14589967916/job/40923057987?pr=7108).