### PR TITLE
chore: Update sentry_protos to 0.1.74

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ prettyplease = { version = "0.2.4", optional = true }
 schemars = { version = "0.8.0", optional = true }
 syn = { version = "2.0.11", optional = true }
 typify = { version = "0.0.16", optional = true }
-sentry_protos = { version = ">=0.1.69", optional = true }
+sentry_protos = { version = "0.1.74", optional = true }
 prost = { version = "0.13", optional = true }
 url = "2.5.4"
 


### PR DESCRIPTION
For some reason, there was a mistake in the code generated to find a Protobuf schema in the list.