### PR TITLE
fix(rust): Fix compilation with no default features enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ lint-python:
 .PHONY: lint-python
 
 lint-rust:
-	cargo clippy -- -W clippy::pedantic
+	cargo clippy --no-default-features --all-targets -- -W clippy::pedantic
+	cargo clippy --all-features --all-targets -- -W clippy::pedantic
 .PHONY: lint-rust
 
 tests:

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -114,6 +114,7 @@ impl Schema {
         Err(SchemaError::InvalidSchema)
     }
 
+    #[cfg(feature = "type_generation")]
     pub fn validate_protobuf(&self, input: &[u8]) -> Result<Box<dyn Any>, SchemaError> {
         if self.schema_type != SchemaType::Protobuf {
             return Err(SchemaError::InvalidType);
@@ -298,6 +299,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "type_generation")]
     fn test_proto_validate() {
         let schema = get_schema("taskworker", None).unwrap();
         let example = schema.examples[0].payload();


### PR DESCRIPTION
Compilation fails if default features are disabled.

This fixes the issue and also adds a check to CI.
