### PR TITLE
feat(taskworker): Add taskworker email and cutover topics configs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -107,6 +107,9 @@
 /topics/taskworker-symbolication-dlq.yaml                     @getsentry/taskbroker
 /topics/taskworker-usage.yaml                                 @getsentry/taskbroker
 /topics/taskworker-usage-dlq.yaml                             @getsentry/taskbroker
+/topics/taskworker-email.yaml                                 @getsentry/taskbroker
+/topics/taskworker-email-dlq.yaml                             @getsentry/taskbroker
+/topics/taskworker-cutover.yaml                               @getsentry/taskbroker
 
 
 # Schemas

--- a/topics/taskworker-cutover.yaml
+++ b/topics/taskworker-cutover.yaml
@@ -1,0 +1,20 @@
+pipeline: taskworker
+description: |
+  A spare topic for maintenance or emergency cutovers
+services:
+  producers:
+    - getsentry/sentry
+  consumers:
+    - getsentry/taskbroker
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.sentry.v1.taskworker_pb2.TaskActivation
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  message.timestamp.type: LogAppendTime
+  max.message.bytes: "10000000"
+  retention.ms: "86400000"

--- a/topics/taskworker-email-dlq.yaml
+++ b/topics/taskworker-email-dlq.yaml
@@ -1,0 +1,19 @@
+pipeline: taskworker
+description: |
+  DLQ for taskworker-email
+services:
+  producers:
+    - getsentry/taskbroker
+  consumers:
+    - getsentry/taskbroker
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.sentry.v1.taskworker_pb2.TaskActivation
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  retention.ms: "604800000" # 7 days
+  max.message.bytes: "10000000"

--- a/topics/taskworker-email.yaml
+++ b/topics/taskworker-email.yaml
@@ -1,0 +1,20 @@
+pipeline: taskworker
+description: |
+  Taskworker tasks to be executed
+services:
+  producers:
+    - getsentry/sentry
+  consumers:
+    - getsentry/taskbroker
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.sentry.v1.taskworker_pb2.TaskActivation
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  message.timestamp.type: LogAppendTime
+  max.message.bytes: "10000000"
+  retention.ms: "86400000"


### PR DESCRIPTION
This PR is responsible for creating default topics configs for taskworker-email, taskworker-email-dlq, and taskworker-cutover. 