### PR TITLE
fix: Add missing fields to buffered-segments and ingest-spans

### DIFF
--- a/examples/buffered-segments/1/basic_buffered_segment.json
+++ b/examples/buffered-segments/1/basic_buffered_segment.json
@@ -21,7 +21,9 @@
         "user": "ip:127.0.0.1"
       },
       "span_id": "95acbe6d30a66717",
-      "start_timestamp_ms": 1706734066840,
+      "start_timestamp_ms": 1715868485371,
+      "start_timestamp_precise": 1715868485.370551,
+      "end_timestamp_precise": 1715868486.370551,
       "trace_id": "8e6f22e6169545cc963255d0f29cb76b"
     },
     {
@@ -45,7 +47,9 @@
         "user": "ip:127.0.0.1"
       },
       "span_id": "95acbe6d30a66717",
-      "start_timestamp_ms": 1706734066840,
+      "start_timestamp_ms": 1715868485371,
+      "start_timestamp_precise": 1715868485.370551,
+      "end_timestamp_precise": 1715868486.370551,
       "trace_id": "8e6f22e6169545cc963255d0f29cb76b"
     }
   ]

--- a/schemas/buffered-segments.v1.schema.json
+++ b/schemas/buffered-segments.v1.schema.json
@@ -59,6 +59,14 @@
           "$ref": "#/definitions/UInt",
           "description": "The start timestamp of the span in milliseconds since epoch."
         },
+        "start_timestamp_precise": {
+          "$ref": "#/definitions/PositiveFloat",
+          "description": "UNIX timestamp in seconds with fractional part up to microsecond precision."
+        },
+        "end_timestamp_precise": {
+          "$ref": "#/definitions/PositiveFloat",
+          "description": "UNIX timestamp in seconds with fractional part up to microsecond precision."
+        },
         "duration_ms": {
           "$ref": "#/definitions/UInt32",
           "description": "The duration of the span in milliseconds."
@@ -92,6 +100,9 @@
         },
         "measurements": {
           "$ref": "#/definitions/Measurements"
+        },
+        "data": {
+          "$ref": "#/definitions/Data"
         }
       },
       "required": [
@@ -102,6 +113,8 @@
         "retention_days",
         "span_id",
         "start_timestamp_ms",
+        "start_timestamp_precise",
+        "end_timestamp_precise",
         "trace_id"
       ]
     },
@@ -184,8 +197,12 @@
         "$ref": "#/definitions/MeasurementValue"
       }
     },
+    "Data": {
+      "type": "object"
+    },
     "MeasurementValue": {
       "type": "object",
+      "title": "measurement_value",
       "properties": {
         "value": {
           "type": "number"


### PR DESCRIPTION
Adds fields that are present and required on `buffered-segments`, but have not
been included in its schema. The preceding `ingest-spans` topic already had
these fields included.

Also exposes `MeasurementValue` as a named type so we can import it in Sentry.

Ref VIEPF-5
Required by https://github.com/getsentry/sentry/pull/92185