### PR TITLE
feat(taskworker): Create taskworker ingest and attachments topics

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -93,6 +93,10 @@
 /topics/taskworker-ingest-errors-dlq.yaml                     @getsentry/taskbroker
 /topics/taskworker-ingest-transactions.yaml                   @getsentry/taskbroker
 /topics/taskworker-ingest-transactions-dlq.yaml               @getsentry/taskbroker
+/topics/taskworker-ingest-attachments.yaml                    @getsentry/taskbroker
+/topics/taskworker-ingest-attachments-dlq.yaml                @getsentry/taskbroker
+/topics/taskworker-ingest-profiling.yaml                      @getsentry/taskbroker
+/topics/taskworker-ingest-profiling-dlq.yaml                  @getsentry/taskbroker
 /topics/taskworker-internal.yaml                              @getsentry/taskbroker
 /topics/taskworker-internal-dlq.yaml                          @getsentry/taskbroker
 /topics/taskworker-limited.yaml                               @getsentry/taskbroker

--- a/topics/taskworker-ingest-attachments-dlq.yaml
+++ b/topics/taskworker-ingest-attachments-dlq.yaml
@@ -1,0 +1,19 @@
+pipeline: taskworker
+description: |
+  DLQ for taskworker-ingest-attachments
+services:
+  producers:
+    - getsentry/taskbroker
+  consumers:
+    - getsentry/taskbroker
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.sentry.v1.taskworker_pb2.TaskActivation
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  retention.ms: "604800000" # 7 days
+  max.message.bytes: "10000000"

--- a/topics/taskworker-ingest-attachments.yaml
+++ b/topics/taskworker-ingest-attachments.yaml
@@ -1,0 +1,20 @@
+pipeline: taskworker
+description: |
+  Taskworker tasks to be executed
+services:
+  producers:
+    - getsentry/sentry
+  consumers:
+    - getsentry/taskbroker
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.sentry.v1.taskworker_pb2.TaskActivation
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  message.timestamp.type: LogAppendTime
+  max.message.bytes: "10000000"
+  retention.ms: "86400000"

--- a/topics/taskworker-ingest-profiling-dlq.yaml
+++ b/topics/taskworker-ingest-profiling-dlq.yaml
@@ -1,0 +1,19 @@
+pipeline: taskworker
+description: |
+  DLQ for taskworker-ingest-profiling
+services:
+  producers:
+    - getsentry/taskbroker
+  consumers:
+    - getsentry/taskbroker
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.sentry.v1.taskworker_pb2.TaskActivation
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  retention.ms: "604800000" # 7 days
+  max.message.bytes: "10000000"

--- a/topics/taskworker-ingest-profiling.yaml
+++ b/topics/taskworker-ingest-profiling.yaml
@@ -1,0 +1,20 @@
+pipeline: taskworker
+description: |
+  Taskworker tasks to be executed
+services:
+  producers:
+    - getsentry/sentry
+  consumers:
+    - getsentry/taskbroker
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.sentry.v1.taskworker_pb2.TaskActivation
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  message.timestamp.type: LogAppendTime
+  max.message.bytes: "10000000"
+  retention.ms: "86400000"


### PR DESCRIPTION
As we prepare taskworker resources in US, we will require these two new topics to house ingest attachments and profiling tasks.