### PR TITLE
feat(uptime): Add optional fields to the `RequestInfo` schema to track more request detail

### DIFF
--- a/schemas/uptime-results.v1.schema.json
+++ b/schemas/uptime-results.v1.schema.json
@@ -74,6 +74,10 @@
           "description": "Status code of the request",
           "type": ["number", "null"]
         },
+        "url": {
+          "description": "The full URL being requested",
+          "type": ["string"]
+        },
         "request_body_size_bytes": {
           "description": "Size of the request body in bytes (per OTEL).",
           "type": ["number", "null"]

--- a/schemas/uptime-results.v1.schema.json
+++ b/schemas/uptime-results.v1.schema.json
@@ -60,10 +60,7 @@
       "required": ["start_us", "duration_us"]
     },
     "NullableTiming": {
-      "oneOf": [
-        { "$ref": "#/definitions/Timing" },
-        { "type": "null" }
-      ]
+      "oneOf": [{ "$ref": "#/definitions/Timing" }, { "type": "null" }]
     },
 
     "RequestInfo": {

--- a/schemas/uptime-results.v1.schema.json
+++ b/schemas/uptime-results.v1.schema.json
@@ -179,7 +179,6 @@
           "type": ["number", "null"]
         },
         "request_info": {
-          "$comment": "This is deprecated and can be removed once we are sending and using `request_info_list`",
           "oneOf": [
             {
               "$ref": "#/definitions/RequestInfo"

--- a/schemas/uptime-results.v1.schema.json
+++ b/schemas/uptime-results.v1.schema.json
@@ -30,7 +30,7 @@
     },
     "CheckStatusReason": {
       "title": "check_status_reason",
-      "description": "Reason for the status, primairly used for failure",
+      "description": "Reason for the status, primarily used for failure",
       "type": "object",
       "properties": {
         "type": {
@@ -43,16 +43,39 @@
       },
       "required": ["type", "description"]
     },
+    "Timing": {
+      "title": "timing",
+      "description": "The time that something started at, and how long it took to finish",
+      "type": "object",
+      "properties": {
+        "start_us": {
+          "description": "Start of the timing, timestamp in microseconds.",
+          "type": "number"
+        },
+        "duration_us": {
+          "description": "Duration of the timing, in microseconds",
+          "type": "number"
+        }
+      },
+      "required": ["start_us", "duration_us"]
+    },
+    "NullableTiming": {
+      "oneOf": [
+        { "$ref": "#/definitions/Timing" },
+        { "type": "null" }
+      ]
+    },
+
     "RequestInfo": {
       "title": "request_info",
-      "description": "Additional information about the request made",
+      "description": "Additional information about each request made",
       "type": "object",
       "properties": {
         "request_type": {
           "$ref": "#/definitions/RequestType"
         },
         "http_status_code": {
-          "description": "Status code of the successful check-in",
+          "description": "Status code of the request",
           "type": ["number", "null"]
         },
         "request_body_size_bytes": {
@@ -63,41 +86,33 @@
           "description": "Size of the response body in bytes (per OTEL).",
           "type": ["number", "null"]
         },
-        "redirect_count": {
-          "description": "Number of redirects encountered before the final request or max threshold.",
-          "type": ["number", "null"]
-        },
         "durations_us": {
           "type": "object",
           "description": "Durations of each operation in the request, in microseconds",
           "properties": {
             "dns_lookup": {
-              "description": "Total time from request initiation until DNS resolution completes. Includes timings from all redirects.",
-              "type": ["number", "null"]
+              "allOf": [{ "$ref": "#/definitions/NullableTiming" }],
+              "description": "Total time from request initiation until DNS resolution completes."
             },
             "tcp_connection": {
-              "description": "Time to establish a TCP connection (excluding TLS). Includes timings from all redirects.",
-              "type": ["number", "null"]
+              "allOf": [{ "$ref": "#/definitions/NullableTiming" }],
+              "description": "Time to establish a TCP connection (excluding TLS)."
             },
             "tls_handshake": {
-              "description": "Time spent on the TLS handshake. Includes timings from all redirects.",
-              "type": ["number", "null"]
+              "allOf": [{ "$ref": "#/definitions/NullableTiming" }],
+              "description": "Time spent on the TLS handshake."
             },
             "time_to_first_byte": {
-              "description": "Time from request start to receiving the first response byte. Includes timings from all redirects.",
-              "type": ["number", "null"]
+              "allOf": [{ "$ref": "#/definitions/NullableTiming" }],
+              "description": "Time from request start to receiving the first response byte."
             },
             "send_request": {
-              "description": "Time spent sending the request (per OTEL conventions).",
-              "type": ["number", "null"]
+              "allOf": [{ "$ref": "#/definitions/NullableTiming" }],
+              "description": "Time spent sending the request (per OTEL conventions)."
             },
             "receive_response": {
-              "description": "Time spent receiving the response (per OTEL).",
-              "type": ["number", "null"]
-            },
-            "redirect": {
-              "description": "Cumulative duration of all redirects before the final request.",
-              "type": ["number", "null"]
+              "allOf": [{ "$ref": "#/definitions/NullableTiming" }],
+              "description": "Time spent receiving the response (per OTEL)."
             }
           },
           "required": [
@@ -106,8 +121,7 @@
             "tls_handshake",
             "time_to_first_byte",
             "send_request",
-            "receive_response",
-            "redirect"
+            "receive_response"
           ]
         }
       },
@@ -161,6 +175,7 @@
           "type": ["number", "null"]
         },
         "request_info": {
+          "$comment": "This is deprecated and can be removed once we are sending and using `request_info_list`",
           "oneOf": [
             {
               "$ref": "#/definitions/RequestInfo"
@@ -169,6 +184,13 @@
               "type": "null"
             }
           ]
+        },
+        "request_info_list": {
+          "description": "List of all request attempts, in order of execution",
+          "type": ["array"],
+          "items": {
+            "$ref": "#/definitions/RequestInfo"
+          }
         },
         "region": {
           "description": "The region that this check was performed in",

--- a/schemas/uptime-results.v1.schema.json
+++ b/schemas/uptime-results.v1.schema.json
@@ -108,7 +108,7 @@
             },
             "time_to_first_byte": {
               "allOf": [{ "$ref": "#/definitions/NullableTiming" }],
-              "description": "Time from request start to receiving the first response byte."
+              "description": "Time from request start to receiving the first response header byte."
             },
             "send_request": {
               "allOf": [{ "$ref": "#/definitions/NullableTiming" }],

--- a/schemas/uptime-results.v1.schema.json
+++ b/schemas/uptime-results.v1.schema.json
@@ -45,7 +45,6 @@
     },
     "Timing": {
       "title": "timing",
-      "description": "The time that something started at, and how long it took to finish",
       "type": "object",
       "properties": {
         "start_us": {

--- a/schemas/uptime-results.v1.schema.json
+++ b/schemas/uptime-results.v1.schema.json
@@ -86,6 +86,10 @@
           "description": "Size of the response body in bytes (per OTEL).",
           "type": ["number", "null"]
         },
+        "request_duration_us": {
+          "description": "Total measured duration for this specific request in microseconds. This is the actual wall clock time and may differ from summing individual timing components.",
+          "type": ["number", "null"]
+        },
         "durations": {
           "type": "object",
           "description": "Durations of each operation in the request",

--- a/schemas/uptime-results.v1.schema.json
+++ b/schemas/uptime-results.v1.schema.json
@@ -54,6 +54,61 @@
         "http_status_code": {
           "description": "Status code of the successful check-in",
           "type": ["number", "null"]
+        },
+        "request_body_size_bytes": {
+          "description": "Size of the request body in bytes (per OTEL).",
+          "type": ["number", "null"]
+        },
+        "response_body_size_bytes": {
+          "description": "Size of the response body in bytes (per OTEL).",
+          "type": ["number", "null"]
+        },
+        "redirect_count": {
+          "description": "Number of redirects encountered before the final request or max threshold.",
+          "type": ["number", "null"]
+        },
+        "durations_us": {
+          "type": "object",
+          "description": "Durations of each operation in the request, in microseconds",
+          "properties": {
+            "dns_lookup": {
+              "description": "Total time from request initiation until DNS resolution completes. Includes timings from all redirects.",
+              "type": ["number", "null"]
+            },
+            "tcp_connection": {
+              "description": "Time to establish a TCP connection (excluding TLS). Includes timings from all redirects.",
+              "type": ["number", "null"]
+            },
+            "tls_handshake": {
+              "description": "Time spent on the TLS handshake. Includes timings from all redirects.",
+              "type": ["number", "null"]
+            },
+            "time_to_first_byte": {
+              "description": "Time from request start to receiving the first response byte. Includes timings from all redirects.",
+              "type": ["number", "null"]
+            },
+            "send_request": {
+              "description": "Time spent sending the request (per OTEL conventions).",
+              "type": ["number", "null"]
+            },
+            "receive_response": {
+              "description": "Time spent receiving the response (per OTEL).",
+              "type": ["number", "null"]
+            },
+            "redirect": {
+              "description": "Cumulative duration of all redirects before the final request.",
+              "type": ["number", "null"]
+            }
+          },
+          "required": [
+            "dns_lookup",
+            "tcp_connection",
+            "tls_handshake",
+            "time_to_first_byte",
+            "send_request",
+            "receive_response",
+            "redirect"
+          ]
         }
       },
       "required": ["request_type", "http_status_code"]

--- a/schemas/uptime-results.v1.schema.json
+++ b/schemas/uptime-results.v1.schema.json
@@ -86,9 +86,9 @@
           "description": "Size of the response body in bytes (per OTEL).",
           "type": ["number", "null"]
         },
-        "durations_us": {
+        "durations": {
           "type": "object",
-          "description": "Durations of each operation in the request, in microseconds",
+          "description": "Durations of each operation in the request",
           "properties": {
             "dns_lookup": {
               "allOf": [{ "$ref": "#/definitions/NullableTiming" }],


### PR DESCRIPTION
This adds timing and extra request detail to the uptime-results `RequestInfo` object. These fields are all optional, and can be null when provided.

Once we have this info, these fields should always be set, and if the information is not available then they should be null.

We can switch these fields over to being required once we're sending this info.