### PR TITLE
ref(snuba-items): add LogAppendTime to snuba-items topic

### DIFF
--- a/topics/snuba-items.yaml
+++ b/topics/snuba-items.yaml
@@ -16,3 +16,4 @@ topic_creation_config:
   compression.type: lz4
   retention.ms: "86400000"
   max.message.bytes: "10000000"
+  message.timestamp.type: LogAppendTime


### PR DESCRIPTION
Add `LogAppendTime` to `snuba-items` since this should have been here when the topic created (like `snuba-spans`)