### PR TITLE
feat(otlp): Add span links definition to buffered segments

### DIFF
--- a/schemas/buffered-segments.v1.schema.json
+++ b/schemas/buffered-segments.v1.schema.json
@@ -103,6 +103,13 @@
         },
         "data": {
           "$ref": "#/definitions/Data"
+        },
+        "links": {
+          "description": "Relationships to other spans",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SpanLink"
+          }
         }
       },
       "required": [
@@ -212,6 +219,25 @@
         }
       },
       "required": ["value"]
+    },
+    "SpanLink": {
+      "type": "object",
+      "title": "span_link",
+      "properties": {
+        "trace_id": {
+          "$ref": "#/definitions/UUID"
+        },
+        "span_id": {
+          "type": "string"
+        },
+        "sampled": {
+          "type": "boolean"
+        },
+        "attributes": {
+          "type": "object"
+        }
+      },
+      "required": ["trace_id", "span_id"]
     }
   }
 }


### PR DESCRIPTION
Relay's `SpanKafkaMessage` sends along span links, as the `links` field. The Kafka definition doesn't have links, and this PR adds the definitions.
