### PR TITLE
feat(tasks) Add taskworker-ingest-errors-postprocess topics

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -94,6 +94,8 @@
 /topics/taskworker-ingest-dlq.yaml                            @getsentry/taskbroker
 /topics/taskworker-ingest-errors.yaml                         @getsentry/taskbroker
 /topics/taskworker-ingest-errors-dlq.yaml                     @getsentry/taskbroker
+/topics/taskworker-ingest-errors-postprocess.yaml             @getsentry/taskbroker
+/topics/taskworker-ingest-errors-postprocess-dlq.yaml         @getsentry/taskbroker
 /topics/taskworker-ingest-transactions.yaml                   @getsentry/taskbroker
 /topics/taskworker-ingest-transactions-dlq.yaml               @getsentry/taskbroker
 /topics/taskworker-ingest-attachments.yaml                    @getsentry/taskbroker

--- a/topics/taskworker-ingest-errors-postprocess-dlq.yaml
+++ b/topics/taskworker-ingest-errors-postprocess-dlq.yaml
@@ -1,0 +1,19 @@
+pipeline: taskworker
+description: |
+  DLQ for taskworker-ingest-errors-postprocess
+services:
+  producers:
+    - getsentry/taskbroker
+  consumers:
+    - getsentry/taskbroker
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.sentry.v1.taskworker_pb2.TaskActivation
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  retention.ms: "604800000" # 7 days
+  max.message.bytes: "10000000"

--- a/topics/taskworker-ingest-errors-postprocess.yaml
+++ b/topics/taskworker-ingest-errors-postprocess.yaml
@@ -1,0 +1,20 @@
+pipeline: taskworker
+description: |
+  Taskworker tasks to be executed
+services:
+  producers:
+    - getsentry/sentry
+  consumers:
+    - getsentry/taskbroker
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.sentry.v1.taskworker_pb2.TaskActivation
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  message.timestamp.type: LogAppendTime
+  max.message.bytes: "10000000"
+  retention.ms: "86400000"


### PR DESCRIPTION
The issues team has requested that post_process_group be operated independently of other error tasks.

Refs getsentry/taskbroker#445