### PR TITLE
feat(otlp): Allow span link attributes to be `null`

### DIFF
--- a/schemas/buffered-segments.v1.schema.json
+++ b/schemas/buffered-segments.v1.schema.json
@@ -234,7 +234,14 @@
           "type": "boolean"
         },
         "attributes": {
-          "type": "object"
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": ["trace_id", "span_id"]


### PR DESCRIPTION
I added this schema in https://github.com/getsentry/sentry-kafka-schemas/pull/422, but it was not correct! The serde definition for the `attributes` field [in Relay](https://github.com/getsentry/relay/blob/995bcfda4079a9f6f944c14e0953391fdddca270/relay-server/src/services/store.rs#L1729) does not include `skip_serializing_if = "Option::is_none"`, so span link `attributes` can in fact be `null`! I'm not sure why this happens in reality, but it seems like at least _some_ SDKs send this, the error can be seen [in production](https://sentry.sentry.io/issues/6765774441).

While I update the code to handle this case, I'm also updating the schema to match reality.