### PR TITLE
fix(issues): Add group-first-seen to merge messages

### DIFF
--- a/schemas/events.v1.schema.json
+++ b/schemas/events.v1.schema.json
@@ -39,6 +39,7 @@
               }
             },
             "new_group_id": { "type": "integer" },
+            "new_group_first_seen": { "$ref": "#/definitions/SnubaDatetime" },
             "datetime": { "$ref": "#/definitions/SnubaDatetime" }
           },
           "additionalProperties": true,
@@ -67,6 +68,7 @@
               "items": { "type": "integer" }
             },
             "new_group_id": { "type": "integer" },
+            "new_group_first_seen": { "$ref": "#/definitions/SnubaDatetime" },
             "datetime": { "$ref": "#/definitions/SnubaDatetime" }
           },
           "additionalProperties": true,


### PR DESCRIPTION
This is part of [fixing sorting by issue age](https://linear.app/getsentry/project/fix-sorting-by-issue-age-8a55870c07a1/overview). That requires us to deal with the merging edge case — rather than trying to do a clever clickhouse query on snuba side (which I do not feel confident in doing without breaking), I'd like to just pass the new group's info along with its id.