### PR TITLE
chore(span-buffer): Add downsampled_retention_days to the SegmentSpan schema

### DIFF
--- a/schemas/buffered-segments.v1.schema.json
+++ b/schemas/buffered-segments.v1.schema.json
@@ -74,6 +74,9 @@
         "retention_days": {
           "$ref": "#/definitions/UInt16"
         },
+        "downsampled_retention_days": {
+          "$ref": "#/definitions/UInt16"
+        },
         "received": {
           "$ref": "#/definitions/PositiveFloat",
           "description": "Unix timestamp when the span was received by Sentry."


### PR DESCRIPTION
A new field will be sent from Relay with the downsampled retention. This is needed since we'll expect this new field.