### PR TITLE
feat(ingest-spans): Add segment_id to spans

### DIFF
--- a/schemas/buffered-segments.v1.schema.json
+++ b/schemas/buffered-segments.v1.schema.json
@@ -45,7 +45,7 @@
         },
         "segment_id": {
           "type": ["string", "null"],
-          "description": "The segment ID is a unique identifier for a segment within a trace. It is an 8 byte hexadecimal string."
+          "description": "The ID of the segment span that this span is nested within. It is an 8 byte hexadecimal string."
         },
         "profile_id": {
           "$ref": "#/definitions/UUID",

--- a/schemas/ingest-spans.v1.schema.json
+++ b/schemas/ingest-spans.v1.schema.json
@@ -29,6 +29,10 @@
           "type": ["string", "null"],
           "description": "The parent span ID is the ID of the span that caused this span. It is an 8 byte hexadecimal string."
         },
+        "segment_id": {
+          "type": ["string", "null"],
+          "description": "The ID of the segment span that this span is nested within. It is an 8 byte hexadecimal string."
+        },
         "profile_id": {
           "$ref": "#/definitions/UUID",
           "description": "The profile ID. It is an 16 byte hexadecimal string."


### PR DESCRIPTION
Relay will continue to output the `segment_id` for spans where it can be known
ahead of time. This especially is the case for spans from transaction events.

