### PR TITLE
ref(schemas-diff): Expand details by default

### DIFF
--- a/scripts/json_schema_changes.py
+++ b/scripts/json_schema_changes.py
@@ -77,9 +77,8 @@ def main() -> None:
     check_for_outdated_repos(consumers, producers)
 
     if breaking_changes:
-        print("<details><summary><strong>changes considered breaking</strong></summary>")
+        print("<strong>changes that might be breaking:</strong>")
         print_files_and_changes(breaking_changes)
-        print("</details>")
 
     if non_breaking_changes:
         print("<details><summary><strong>benign changes</strong></summary>")


### PR DESCRIPTION
I've been asked twice by different ppl why a schema is breaking, and it
seems that the message is too dense or poorly formatted to drive the
point home. Expand details and hope that helps
