### PR TITLE
create LW delete eap-items schema and topic

### DIFF
--- a/examples/snuba-lw-deletions-eap-items/1/snuba-lw-deletions-eap-items.json
+++ b/examples/snuba-lw-deletions-eap-items/1/snuba-lw-deletions-eap-items.json
@@ -1,0 +1,18 @@
+{
+  "storage_name": "eap_items",
+  "rows_to_delete": 1000,
+  "conditions": {
+    "organization_id": [1],
+    "project_id": [1],
+    "trace_id": [
+        "550e8400-e29b-41d4-a716-446655440000",
+        "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+        "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+    ]
+  },
+  "tenant_ids": {
+    "project_id": 1,
+    "organization_id": 1,
+    "referrer": "some_referrer"
+  }
+}

--- a/schemas/snuba-lw-deletions-eap-items.v1.json
+++ b/schemas/snuba-lw-deletions-eap-items.v1.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "lw_delete_eap_items",
+  "type": "object",
+  "properties": {
+    "storage_name": {
+      "type": "string"
+    },
+    "rows_to_delete": {
+      "type": "integer"
+    },
+    "conditions": {
+      "type": "object",
+      "properties": {
+        "organization_id": {
+          "type": "array",
+          "items": { "type": "integer" }
+        },
+        "project_id": {
+          "type": "array",
+          "items": { "type": "integer" }
+        },
+        "trace_id": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "tenant_ids": {
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [{ "type": "string" }, { "type": "integer", "minimum": 1 }]
+      }
+    }
+  },
+  "required": ["storage_name", "rows_to_delete", "conditions", "tenant_ids"]
+}

--- a/topics/snuba-lw-deletions-eap-items.yaml
+++ b/topics/snuba-lw-deletions-eap-items.yaml
@@ -1,0 +1,19 @@
+pipeline: items
+description: Snuba Lightweight Deletes (EAP Items)
+services:
+  consumers:
+    - getsentry/snuba
+  producers:
+    - getsentry/snuba
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: json
+    resource: snuba-lw-deletions-eap-items.v1.schema.json
+    examples:
+      - snuba-lw-deletions-eap-items/1/
+topic_creation_config:
+  compression.type: lz4
+  max.message.bytes: "50000000"
+  retention.ms: "86400000"
+  message.timestamp.type: LogAppendTime


### PR DESCRIPTION
create schema, topic, and example for eap-items deletions

in support of https://linear.app/getsentry/issue/EAP-282/create-new-rpc-endpoint-for-deletion-from-eap-items
