### PR TITLE
fix(spans): Add _meta field to ingest spans

### DIFF
--- a/schemas/ingest-spans.v1.schema.json
+++ b/schemas/ingest-spans.v1.schema.json
@@ -70,6 +70,9 @@
         },
         "attributes": {
           "$ref": "file://ingest-spans.v1.schema.json#/definitions/Attributes"
+        },
+        "_meta": {
+          "type": "object"
         }
       },
       "required": [


### PR DESCRIPTION
See e.g. https://github.com/getsentry/relay/blob/a9900633af67a82283ebe58c257ec527f9bf03ff/tests/integration/test_spansv2.py#L96-L108 for a test verifying that `_meta` is written to spans.

The type of `_meta` is complex. For now, just acknowledge that it is present in the schema.