### PR TITLE
feat(tasks) Add topic for seer taskworker

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -109,6 +109,8 @@
 /topics/taskworker-internal-dlq.yaml                          @getsentry/taskbroker
 /topics/taskworker-launchpad.yaml                             @getsentry/taskbroker
 /topics/taskworker-launchpad-dlq.yaml                         @getsentry/taskbroker
+/topics/taskworker-seer.yaml                                  @getsentry/taskbroker
+/topics/taskworker-seer-dlq.yaml                              @getsentry/taskbroker
 /topics/taskworker-limited.yaml                               @getsentry/taskbroker
 /topics/taskworker-limited-dlq.yaml                           @getsentry/taskbroker
 /topics/taskworker-long.yaml                                  @getsentry/taskbroker

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -109,14 +109,14 @@
 /topics/taskworker-internal-dlq.yaml                          @getsentry/taskbroker
 /topics/taskworker-launchpad.yaml                             @getsentry/taskbroker
 /topics/taskworker-launchpad-dlq.yaml                         @getsentry/taskbroker
-/topics/taskworker-seer.yaml                                  @getsentry/taskbroker
-/topics/taskworker-seer-dlq.yaml                              @getsentry/taskbroker
 /topics/taskworker-limited.yaml                               @getsentry/taskbroker
 /topics/taskworker-limited-dlq.yaml                           @getsentry/taskbroker
 /topics/taskworker-long.yaml                                  @getsentry/taskbroker
 /topics/taskworker-long-dlq.yaml                              @getsentry/taskbroker
 /topics/taskworker-products.yaml                              @getsentry/taskbroker
 /topics/taskworker-products-dlq.yaml                          @getsentry/taskbroker
+/topics/taskworker-seer.yaml                                  @getsentry/taskbroker
+/topics/taskworker-seer-dlq.yaml                              @getsentry/taskbroker
 /topics/taskworker-sentryapp.yaml                             @getsentry/taskbroker
 /topics/taskworker-sentryapp-dlq.yaml                         @getsentry/taskbroker
 /topics/taskworker-symbolication.yaml                         @getsentry/taskbroker

--- a/python/tests/test_valid_topic_data.py
+++ b/python/tests/test_valid_topic_data.py
@@ -58,14 +58,15 @@ _TOPIC_SCHEMA = fastjsonschema.compile(
             "Repo": {
                 "enum": [
                     # enumerate all repos here to avoid typos
+                    "getsentry/launchpad",
                     "getsentry/relay",
+                    "getsentry/seer",
                     "getsentry/sentry",
                     "getsentry/snuba",
-                    "getsentry/vroom",
-                    "getsentry/uptime-checker",
                     "getsentry/super-big-consumers",
                     "getsentry/taskbroker",
-                    "getsentry/launchpad",
+                    "getsentry/vroom",
+                    "getsentry/uptime-checker",
                 ]
             }
         },

--- a/topics/taskworker-seer-dlq.yaml
+++ b/topics/taskworker-seer-dlq.yaml
@@ -3,9 +3,9 @@ description: |
   DLQ for taskworker-seer
 services:
   producers:
-    - getsentry/seer
+    - getsentry/taskbroker
   consumers:
-    - getsentry/seer
+    - getsentry/taskbroker
 schemas:
   - version: 1
     compatibility_mode: none

--- a/topics/taskworker-seer-dlq.yaml
+++ b/topics/taskworker-seer-dlq.yaml
@@ -1,0 +1,19 @@
+pipeline: taskworker
+description: |
+  DLQ for taskworker-seer
+services:
+  producers:
+    - getsentry/seer
+  consumers:
+    - getsentry/seer
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.sentry.v1.taskworker_pb2.TaskActivation
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  retention.ms: "604800000" # 7 days
+  max.message.bytes: "10000000"

--- a/topics/taskworker-seer.yaml
+++ b/topics/taskworker-seer.yaml
@@ -1,0 +1,21 @@
+pipeline: taskworker
+description: |
+  Taskworker tasks to be executed by seer.
+services:
+  producers:
+    - getsentry/sentry
+    - getsentry/seer
+  consumers:
+    - getsentry/seer
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.sentry.v1.taskworker_pb2.TaskActivation
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  message.timestamp.type: LogAppendTime
+  max.message.bytes: "10000000"
+  retention.ms: "86400000"

--- a/topics/taskworker-seer.yaml
+++ b/topics/taskworker-seer.yaml
@@ -6,7 +6,7 @@ services:
     - getsentry/sentry
     - getsentry/seer
   consumers:
-    - getsentry/seer
+    - getsentry/taskbroker
 schemas:
   - version: 1
     compatibility_mode: none


### PR DESCRIPTION
Seer is will be moving to taskbroker for its internal tasks and tasks spawned from sentry.

Refs STREAM-864