### PR TITLE
chore(topics): Increase max.message.bytes for snuba-dead-letter-items to 15MB

### DIFF
--- a/python/tests/test_valid_topic_data.py
+++ b/python/tests/test_valid_topic_data.py
@@ -185,6 +185,11 @@ def test_dlq_configuration() -> None:
     dlq_suffix = "-dlq"
     snuba_dlq_prefix = "snuba-dead-letter-"
 
+    # DLQs that are intentionally allowed to diverge from their main topic's max.message.bytes
+    skip_max_message_bytes_check = {
+        "snuba-dead-letter-items",
+    }
+
     for filename in topics_dir.iterdir():
         if filename.stem.endswith(dlq_suffix):
             main_topic_name = custom_dlq_mapping.get(
@@ -206,9 +211,10 @@ def test_dlq_configuration() -> None:
             main_topic_data = safe_load(main_topic_file)
 
             # max.message.bytes matches
-            assert dlq_topic_data["topic_creation_config"].get(
-                "max.message.bytes"
-            ) == main_topic_data["topic_creation_config"].get("max.message.bytes")
+            if filename.stem not in skip_max_message_bytes_check:
+                assert dlq_topic_data["topic_creation_config"].get(
+                    "max.message.bytes"
+                ) == main_topic_data["topic_creation_config"].get("max.message.bytes")
 
             # DLQ has 7 day retention
             assert dlq_topic_data["topic_creation_config"]["retention.ms"] == str(

--- a/topics/snuba-dead-letter-items.yaml
+++ b/topics/snuba-dead-letter-items.yaml
@@ -16,4 +16,4 @@ schemas:
 topic_creation_config:
   compression.type: lz4
   retention.ms: "604800000" # 7 days
-  max.message.bytes: "10000000"
+  max.message.bytes: "15000000"


### PR DESCRIPTION
I recently created a consumer that writes to the dlq topic but it was running into `{"message":"Strategy(ProducerFailure { error: \"MessageProduction(MessageSizeTooLarge (Broker: Message size too large))\" })"},"target":"rust_snuba::consumer"}`This was unexpected as I am simply dlq-ing messages from the original topic which has the same max-size. But anyways, in an attempt to fix this issue I will raise the max-message-size for the dlq topic and run my test again.

I had to disable one of the tests for this topic in order to allow the dlq max size to differ from the main topic max size

## Summary
- Increases `max.message.bytes` from 10MB to 15MB for the `snuba-dead-letter-items` topic

## Test plan
- [ ] CI passes