### PR TITLE
feat(topics): Add snuba-dead-letter-accepted-outcomes DLQ topic

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -189,3 +189,4 @@
 /topics/scheduled-subscriptions-eap-items.yaml @getsentry/events-analytics-platform
 /topics/subscription-results-eap-items.yaml    @getsentry/events-analytics-platform
 /topics/snuba-dead-letter-items.yaml           @getsentry/events-analytics-platform
+/topics/snuba-dead-letter-accepted-outcomes.yaml  @getsentry/events-analytics-platform

--- a/python/tests/test_valid_topic_data.py
+++ b/python/tests/test_valid_topic_data.py
@@ -179,6 +179,7 @@ def test_dlq_configuration() -> None:
         "snuba-dead-letter-querylog": "snuba-queries",
         "snuba-dead-letter-generic-metrics": "snuba-generic-metrics",
         "snuba-dead-letter-items": "snuba-items",
+        "snuba-dead-letter-accepted-outcomes": "snuba-items",
     }
 
     topics_dir = _TOPICS

--- a/topics/snuba-dead-letter-accepted-outcomes.yaml
+++ b/topics/snuba-dead-letter-accepted-outcomes.yaml
@@ -1,0 +1,19 @@
+pipeline: items
+description: DLQ for snuba-items accepted outcomes
+services:
+  producers:
+    - getsentry/snuba
+  consumers: []
+schemas:
+  # this schema is just a placeholder bc its required, ideally the dlq shouldnt
+  # have a schema but its required.
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.snuba.v1.trace_item_pb2.TraceItem
+    examples:
+      - snuba-items/1/
+topic_creation_config:
+  compression.type: lz4
+  retention.ms: "604800000" # 7 days
+  max.message.bytes: "10000000"


### PR DESCRIPTION
**Context**
 The new accepted outcomes consumer consumes from the `snuba-items` topic and produces to the `outcomes-billing` topic. 

In terms of invalid messages, if the problem was with parsing the `TraceItem` - we will see the same message DLQ for both the `eap-items-consumer` and the `accepted-outcomes-consumer`, since they both parse the required parameters: `org_id`,`project_id`, `timestamp`, `trace_id`, and `item_id`. If the problem is with the shape of the outcomes themselves, then relay or some other upstream service is sending bad outcome data and we will DLQ while the `eap-items-consumer` keeps ingesting. This should not be expected to happen after a rollout of outcomes on EAP, but if it did then the customer impact would be a delayed charge in outcomes OR receiving data they are not charged for (if we do not replay those messages from the DLQ).
 

**Changes**
- Add new DLQ topic `snuba-dead-letter-accepted-outcomes` for the snuba-items pipeline (7-day retention, lz4, matches `snuba-items` `max.message.bytes`)
- Register the topic in `CODEOWNERS` under `@getsentry/events-analytics-platform`
- Add it to the custom DLQ-to-main-topic mapping in `test_valid_topic_data.py` so `test_dlq_configuration` resolves it to `snuba-items`


🤖 Generated with [Claude Code](https://claude.com/claude-code)