### PR TITLE
feat(taskbroker): Add `taskworker-push` Topic

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -79,6 +79,7 @@
 
 # Topic for taskworker
 /topics/taskworker.yaml                                       @getsentry/taskbroker
+/topics/taskworker-push.yaml                                  @getsentry/taskbroker
 /topics/taskworker-dlq.yaml                                   @getsentry/taskbroker
 /topics/taskworker-billing.yaml                               @getsentry/taskbroker
 /topics/taskworker-billing-dlq.yaml                           @getsentry/taskbroker

--- a/topics/taskworker-push.yaml
+++ b/topics/taskworker-push.yaml
@@ -1,0 +1,20 @@
+pipeline: taskworker
+description: |
+  Taskworker tasks to be executed
+services:
+  producers:
+    - getsentry/sentry
+  consumers:
+    - getsentry/taskbroker
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.sentry.v1.taskworker_pb2.TaskActivation
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  message.timestamp.type: LogAppendTime
+  max.message.bytes: "10000000"
+  retention.ms: "86400000"


### PR DESCRIPTION
## Linear
Refs [STREAM-966](https://linear.app/getsentry/issue/STREAM-966/create-default-push-alloydb-pool)

## Description
Create a `taskworker-push` topic for the push version of the `default` processing pool.