### PR TITLE
fix(transactions): allow nullable measurements, breakdowns, and measurement entries

### DIFF
--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -298,10 +298,16 @@
           }
         },
         "measurements": {
-          "$ref": "#/definitions/Measurements"
+          "anyOf": [
+            { "$ref": "#/definitions/Measurements" },
+            { "type": "null" }
+          ]
         },
         "breakdowns": {
-          "$ref": "#/definitions/Breakdowns"
+          "anyOf": [
+            { "$ref": "#/definitions/Breakdowns" },
+            { "type": "null" }
+          ]
         },
         "culprit": {
           "type": "string"
@@ -859,9 +865,18 @@
     },
     "Measurements": {
       "type": "object",
+      "additionalProperties": {
+        "anyOf": [
+          { "$ref": "#/definitions/NumOfSpans" },
+          { "type": "null" }
+        ]
+      },
       "properties": {
         "num_of_spans": {
-          "$ref": "#/definitions/NumOfSpans"
+          "anyOf": [
+            { "$ref": "#/definitions/NumOfSpans" },
+            { "type": "null" }
+          ]
         }
       }
     },

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -298,13 +298,10 @@
           }
         },
         "measurements": {
-          "anyOf": [
-            { "$ref": "#/definitions/Measurements" },
-            { "type": "null" }
-          ]
+          "$ref": "#/definitions/Measurements"
         },
         "breakdowns": {
-          "anyOf": [{ "$ref": "#/definitions/Breakdowns" }, { "type": "null" }]
+          "$ref": "#/definitions/Breakdowns"
         },
         "culprit": {
           "type": "string"
@@ -334,7 +331,7 @@
       ]
     },
     "Breakdowns": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": true,
       "properties": {
         "span_ops": {
@@ -861,13 +858,10 @@
       "additionalProperties": true
     },
     "Measurements": {
-      "type": "object",
-      "additionalProperties": {
-        "anyOf": [{ "$ref": "#/definitions/NumOfSpans" }, { "type": "null" }]
-      },
+      "type": ["object", "null"],
       "properties": {
         "num_of_spans": {
-          "anyOf": [{ "$ref": "#/definitions/NumOfSpans" }, { "type": "null" }]
+          "$ref": "#/definitions/NumOfSpans"
         }
       }
     },

--- a/schemas/transactions.v1.schema.json
+++ b/schemas/transactions.v1.schema.json
@@ -304,10 +304,7 @@
           ]
         },
         "breakdowns": {
-          "anyOf": [
-            { "$ref": "#/definitions/Breakdowns" },
-            { "type": "null" }
-          ]
+          "anyOf": [{ "$ref": "#/definitions/Breakdowns" }, { "type": "null" }]
         },
         "culprit": {
           "type": "string"
@@ -866,17 +863,11 @@
     "Measurements": {
       "type": "object",
       "additionalProperties": {
-        "anyOf": [
-          { "$ref": "#/definitions/NumOfSpans" },
-          { "type": "null" }
-        ]
+        "anyOf": [{ "$ref": "#/definitions/NumOfSpans" }, { "type": "null" }]
       },
       "properties": {
         "num_of_spans": {
-          "anyOf": [
-            { "$ref": "#/definitions/NumOfSpans" },
-            { "type": "null" }
-          ]
+          "anyOf": [{ "$ref": "#/definitions/NumOfSpans" }, { "type": "null" }]
         }
       }
     },


### PR DESCRIPTION
## Summary

Relay replaces invalid SDK-supplied field values with `null` rather than omitting them. The transactions schema did not account for this, causing validation failures when `measurements` or `breakdowns` arrive as `null`.

- `measurements` field in `Data` is now nullable (`anyOf: [Measurements, null]`)
- `breakdowns` field in `Data` is now nullable (`anyOf: [Breakdowns, null]`)
- Individual entries inside `Measurements` are now nullable (`additionalProperties` allows `NumOfSpans | null`, and `num_of_spans` itself is `NumOfSpans | null`)

Addresses review comment: https://linear.app/getsentry/review/fixtransactions-default-null-measurements-to-an-empty-object-a72e94787c66#comment-73e9ca52

## Test plan

- [x] All existing example validation tests pass (`549 passed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cffb1Z7voprAuHqnwNhYGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cffb1Z7voprAuHqnwNhYGv)_