### PR TITLE
feat(taskbroker): Add `taskworker-launchpad-push` topic

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -111,6 +111,7 @@
 /topics/taskworker-internal-dlq.yaml                          @getsentry/taskbroker
 /topics/taskworker-launchpad.yaml                             @getsentry/taskbroker
 /topics/taskworker-launchpad-dlq.yaml                         @getsentry/taskbroker
+/topics/taskworker-launchpad-push.yaml                        @getsentry/streaming-platform
 /topics/taskworker-limited.yaml                               @getsentry/taskbroker
 /topics/taskworker-limited-dlq.yaml                           @getsentry/taskbroker
 /topics/taskworker-long.yaml                                  @getsentry/taskbroker

--- a/topics/taskworker-launchpad-push.yaml
+++ b/topics/taskworker-launchpad-push.yaml
@@ -1,0 +1,21 @@
+pipeline: taskworker
+description: |
+  Taskworker tasks to be executed by launchpad.
+services:
+  producers:
+    - getsentry/sentry
+    - getsentry/launchpad
+  consumers:
+    - getsentry/taskbroker
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.sentry.v1.taskworker_pb2.TaskActivation
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  message.timestamp.type: LogAppendTime
+  max.message.bytes: "10000000"
+  retention.ms: "86400000"


### PR DESCRIPTION
Registers the `taskworker-launchpad-push` topic.

Mirrors `taskworker-launchpad`: taskworker pipeline, protobuf `TaskActivation` schema (v1). Adds the CODEOWNERS entry for `@getsentry/streaming-platform`.

Part of standing up the `taskworker-launchpad-push` topic (ops + sentry PRs to follow). A new release of this package is required before the ops/sentry dependency pins can be bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)