### PR TITLE
feat(loadbalancer-outcomes): Add loadbalancer-outcomes topic

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -47,6 +47,9 @@
 /topics/buffered-segments.yaml                                 @getsentry/owners-snuba @getsentry/data-browsing
 /topics/buffered-segments-dlq.yaml                             @getsentry/owners-snuba @getsentry/data-browsing
 
+# Topic used for Anti-Abuse outcomes
+/topics/loadbalancer-outcomes.yaml                             @getsentry/ops
+
 # DLQs for Snuba topics
 /topics/snuba-dead-letter-metrics.yaml                         @getsentry/owners-snuba
 /topics/snuba-dead-letter-generic-metrics.yaml                 @getsentry/owners-snuba

--- a/python/tests/test_valid_topic_data.py
+++ b/python/tests/test_valid_topic_data.py
@@ -59,14 +59,15 @@ _TOPIC_SCHEMA = fastjsonschema.compile(
                 "enum": [
                     # enumerate all repos here to avoid typos
                     "getsentry/launchpad",
+                    "getsentry/ops",
                     "getsentry/relay",
                     "getsentry/seer",
                     "getsentry/sentry",
                     "getsentry/snuba",
                     "getsentry/super-big-consumers",
                     "getsentry/taskbroker",
-                    "getsentry/vroom",
                     "getsentry/uptime-checker",
+                    "getsentry/vroom",
                 ]
             }
         },

--- a/topics/loadbalancer-outcomes.yaml
+++ b/topics/loadbalancer-outcomes.yaml
@@ -1,0 +1,19 @@
+pipeline: outcomes
+description: Outcomes for events sent to Sentry and rejected by Anti-Abuse
+services:
+  producers:
+    - getsentry/ops
+  consumers:
+    - getsentry/snuba
+    - getsentry/super-big-consumers
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: json
+    resource: outcomes.v1.schema.json
+    examples:
+      - outcomes/1/
+topic_creation_config:
+  compression.type: lz4
+  retention.ms: "86400000"
+  segment.bytes: "262144000"


### PR DESCRIPTION
E.g. https://github.com/getsentry/ops/blob/master/shared_config/kafka/topics/regional_overrides/us/loadbalancer-outcomes.yaml

Checked the generated output of topicctl for the `topic_creation_config`.