### PR TITLE
feat(shared-resources-usage): add operations usage_unit

### DIFF
--- a/schemas/shared-resources-usage.v1.schema.json
+++ b/schemas/shared-resources-usage.v1.schema.json
@@ -17,7 +17,7 @@
           "type": "string"
         },
         "usage_unit": {
-          "enum": ["bytes", "milliseconds", "milliseconds_sec"]
+          "enum": ["bytes", "milliseconds", "milliseconds_sec", "operations"]
         },
         "amount": {
           "type": "integer"


### PR DESCRIPTION
## Summary
- Adds `"operations"` to the `usage_unit` enum in `shared-resources-usage.v1.schema.json`.
- Producers are emitting `usage_unit="operations"` against the `shared-resources-usage` topic, but the schema only allowed `bytes` / `milliseconds` / `milliseconds_sec`, so downstream consumers fail validation with:
  > `JsonSchemaValueException: data.usage_unit must be one of ['bytes', 'milliseconds', 'milliseconds_sec']`

This is a forward-compatible additive enum change.

## Test plan
- [ ] CI schema validation passes
- [ ] Confirm with @getsentry/owners-snuba / @getsentry/data that `operations` is the intended unit name
- [ ] After merge + release, bump `sentry-kafka-schemas` in the consumer and verify the previously failing message validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)