### PR TITLE
feat(taskbroker): add schema for the taskworker-process-segment topic

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -104,6 +104,8 @@
 /topics/taskworker-ingest-errors-postprocess-dlq.yaml         @getsentry/taskbroker
 /topics/taskworker-ingest-transactions.yaml                   @getsentry/taskbroker
 /topics/taskworker-ingest-transactions-dlq.yaml               @getsentry/taskbroker
+/topics/taskworker-process-segments.yaml                      @getsentry/taskbroker
+/topics/taskworker-process-segments-dlq.yaml                  @getsentry/taskbroker
 /topics/taskworker-ingest-attachments.yaml                    @getsentry/taskbroker
 /topics/taskworker-ingest-attachments-dlq.yaml                @getsentry/taskbroker
 /topics/taskworker-ingest-profiling.yaml                      @getsentry/taskbroker

--- a/topics/taskworker-process-segments-dlq.yaml
+++ b/topics/taskworker-process-segments-dlq.yaml
@@ -1,0 +1,19 @@
+pipeline: taskworker
+description: |
+  DLQ for taskworker-process-segments
+services:
+  producers:
+    - getsentry/taskbroker
+  consumers:
+    - getsentry/taskbroker
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.sentry.v1.taskworker_pb2.TaskActivation
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  retention.ms: "604800000" # 7 days
+  max.message.bytes: "25000000"

--- a/topics/taskworker-process-segments.yaml
+++ b/topics/taskworker-process-segments.yaml
@@ -1,0 +1,20 @@
+pipeline: taskworker
+description: |
+  Taskworker tasks to be executed
+services:
+  producers:
+    - getsentry/sentry
+  consumers:
+    - getsentry/taskbroker
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: protobuf
+    resource: sentry_protos.sentry.v1.taskworker_pb2.TaskActivation
+    examples:
+      - taskworker/1/
+topic_creation_config:
+  compression.type: lz4
+  message.timestamp.type: LogAppendTime
+  max.message.bytes: "25000000"
+  retention.ms: "86400000"


### PR DESCRIPTION
Refs STREAM-1304

Adds the schema for the taskworker-process-segment topic that will be used for porting the segments consumers to taskbroker tasks.