### PR TITLE
feat(cogs): new shared-resources-inventory topic

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -69,6 +69,9 @@
 # Topics produced to by Snuba and Sentry
 /topics/shared-resources-usage.yaml                            @getsentry/owners-snuba @getsentry/data
 
+# Shared resource inventory, used as COGS enrichment data
+/topics/shared-resources-inventory.yaml                        @getsentry/foundational-storage @getsentry/data
+
 # Topics related to cron monitor tasks
 /topics/monitors-clock-tick.yaml                               @getsentry/crons
 /topics/monitors-clock-tasks.yaml                              @getsentry/crons
@@ -98,6 +101,7 @@
 /schemas/snuba-items.v1.schema.json                            @getsentry/events-analytics-platform
 /schemas/taskworker.v1.schema.json                             @getsentry/taskbroker
 /schemas/snuba-llm-proxy-cost.v1.schema.json                   @getsentry/machine-learning-ai
+/schemas/shared-resources-inventory.v1.schema.json             @getsentry/foundational-storage @getsentry/data
 
 
 # Examples
@@ -118,6 +122,7 @@
 /examples/snuba-items/                                         @getsentry/events-analytics-platform
 /examples/taskworker/                                          @getsentry/taskbroker
 /examples/snuba-llm-proxy-cost/                                @getsentry/machine-learning-ai
+/examples/shared-resources-inventory/                          @getsentry/foundational-storage @getsentry/data
 
 # Internal Snuba topics
 /topics/snuba-queries.yaml                                     @getsentry/owners-snuba

--- a/examples/shared-resources-inventory/1/delete.json
+++ b/examples/shared-resources-inventory/1/delete.json
@@ -1,0 +1,12 @@
+{
+  "shared_resource_id": "example_resource",
+  "app_feature": "example_feature",
+  "op_type": "DELETE",
+  "record_id": "3f7a1c2e9b4d5a6f8c0e1d2b3a4f5e6c",
+  "timestamp": 1785456000000000,
+  "sample_rate": 1,
+  "size": null,
+  "expiration_time": null,
+  "organization_id": 1,
+  "project_id": 1
+}

--- a/examples/shared-resources-inventory/1/update.json
+++ b/examples/shared-resources-inventory/1/update.json
@@ -1,0 +1,12 @@
+{
+  "shared_resource_id": "example_resource",
+  "app_feature": "example_feature",
+  "op_type": "UPDATE",
+  "record_id": "3f7a1c2e9b4d5a6f8c0e1d2b3a4f5e6c",
+  "timestamp": 1785369600000000,
+  "sample_rate": 1,
+  "size": null,
+  "expiration_time": 1785974400000000,
+  "organization_id": 1,
+  "project_id": 1
+}

--- a/examples/shared-resources-inventory/1/write.json
+++ b/examples/shared-resources-inventory/1/write.json
@@ -1,0 +1,12 @@
+{
+  "shared_resource_id": "example_resource",
+  "app_feature": "example_feature",
+  "op_type": "WRITE",
+  "record_id": "3f7a1c2e9b4d5a6f8c0e1d2b3a4f5e6c",
+  "timestamp": 1785283200000000,
+  "sample_rate": 1,
+  "size": 524288,
+  "expiration_time": 1785888000000000,
+  "organization_id": 1,
+  "project_id": 1
+}

--- a/python/tests/test_valid_topic_data.py
+++ b/python/tests/test_valid_topic_data.py
@@ -59,6 +59,7 @@ _TOPIC_SCHEMA = fastjsonschema.compile(
                 "enum": [
                     # enumerate all repos here to avoid typos
                     "getsentry/launchpad",
+                    "getsentry/objectstore",
                     "getsentry/ops",
                     "getsentry/relay",
                     "getsentry/seer",

--- a/schemas/shared-resources-inventory.v1.schema.json
+++ b/schemas/shared-resources-inventory.v1.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "shared_resources_inventory",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "shared_resource_id": {
+      "type": "string",
+      "description": "Identifies the shared resource this record belongs to. Matches the shared_resource_id label on the billed GCP resource."
+    },
+    "app_feature": {
+      "type": "string",
+      "description": "The product feature this record is attributed to."
+    },
+    "op_type": {
+      "enum": ["WRITE", "UPDATE", "DELETE"],
+      "description": "WRITE creates or replaces a record. UPDATE mutates fields of an existing record without changing its stored size (to, for example, extend an expiration deadline). DELETE removes it."
+    },
+    "record_id": {
+      "type": "string",
+      "description": "Opaque stable identifier for the stored record, unique within a shared_resource_id. It is recommended that producers use a hash (e.g. BLAKE3) of some app-level ID. Once decided, it shouldn't be changed."
+    },
+    "timestamp": {
+      "type": "integer",
+      "description": "Unix epoch microseconds at which the operation occurred. NOTE: this differs from shared-resources-usage, which uses epoch seconds. Microsecond resolution keeps same-instant collisions rare enough that ordering per record_id can be resolved by timestamp plus a fixed op_type precedence."
+    },
+    "sample_rate": {
+      "type": "number",
+      "exclusiveMinimum": 0,
+      "maximum": 1,
+      "description": "Proportion of records the producer is emitting for this shared_resource_id. Producers that emit every record set this to 1. Consumers/pipelines may use `1 / sample_rate` as a weight when computing rollups to keep the rollup proportionally stable even when sample_rate changes."
+    },
+    "size": {
+      "type": ["integer", "null"],
+      "description": "Stored size in bytes. Required for op_type=WRITE. Omitted for DELETE, and for UPDATE when the size is unchanged."
+    },
+    "expiration_time": {
+      "type": ["integer", "null"],
+      "description": "Unix epoch microseconds at which the record is expected to be reclaimed by the backend, if known. Backends that expire records without notifying the producer rely on this for downstream removal."
+    },
+    "organization_id": {
+      "type": ["integer", "null"],
+      "description": "Sentry organization ID the record is attributed to, if known."
+    },
+    "project_id": {
+      "type": ["integer", "null"],
+      "description": "Sentry project ID the record is attributed to, if known."
+    }
+  },
+  "required": [
+    "app_feature",
+    "op_type",
+    "record_id",
+    "sample_rate",
+    "shared_resource_id",
+    "timestamp"
+  ]
+}

--- a/topics/shared-resources-inventory.yaml
+++ b/topics/shared-resources-inventory.yaml
@@ -1,0 +1,19 @@
+description: >
+  Per-record inventory change stream for shared storage resources. Producers emit
+  WRITE/UPDATE/DELETE records describing what they store; consumers reconstruct
+  current bytes-stored per app_feature for use as COGS enrichment data.
+services:
+  producers:
+    - getsentry/objectstore
+  consumers:
+    - getsentry/super-big-consumers
+schemas:
+  - version: 1
+    compatibility_mode: none
+    type: json
+    resource: shared-resources-inventory.v1.schema.json
+    examples:
+      - shared-resources-inventory/1/
+topic_creation_config:
+  compression.type: lz4
+  retention.ms: "86400000"


### PR DESCRIPTION
Ref FS-210
Notion doc: https://app.notion.com/p/sentry/Project-COGS-32a8b10e4b5d804c9754f0df1067dcf5

Objectstore is implementing COGS breakdowns for our stored data. Our plan is to emit a stream of change events to Kafka, "merge" that stream into a BigQuery table describing each object we store, its size, and its attribution information, and then run a rollup on that table for the COGS pipeline. We are planning to use the same `Kafka -> GCS -> Airflow -> cogs.all_costs` structure as the existing `shared-resources-usage` / `usage-accountant` COGS pipeline but catered to "stock" metrics rather than "flow" metrics. Like the existing pipeline, any Sentry service can use this to maintain a similar inventory table for COGS or other purposes.

Conceptually, a Bigtable Change Data Capture (CDC) stream is basically what we want. However, for COGS purposes Objectstore only needs to stream metadata changes whereas CDC forces us to stream entire rows. For Objectstore, this means we process like 400x more data and it costs way, way more. This approach is cheaper, and it's generalizable to boot.

# Scale considerations



Each PUT/POST/DELETE operation will emit either 1 or 2 Kafka messages depending on whether the object lives in Bigtable or GCS. If it lives in Bigtable, we emit just the one message for the Bigtable write. If it lives in GCS, we emit one message for the GCS write and one message for the redirect tombstone that we write to Bigtable.

Each GET operation will emit between 0 and 2 Kafka messages. If the object has a TTL or manual expiration policy, or a TTI policy but its TTI was already updated recently, then a GET will not emit any messages. If it has a TTI policy and our debounce filter doesn't trigger, then it will emit 1 message for a TTI bump in Bigtable and, if the object lives in GCS, 1 additional message for the TTI bump in GCS.

It's difficult to project how many messages per second we'll need to handle in reality, but let's lay out the worst case in our largest region (`us`):
- 530 PUT/POST requests/s -> max 1060 messages per second
- 130 DELETE requests/s -> max 260 messages per second
- 110 GET requests/s -> max 220 messages per second

Total: 1540 messages per second, worst case. The real figure is probably much closer to 770 since nearly every object we store lives in Bigtable. Other regions are way, way smaller.

Messages will be somewhere around 500 bytes per message. So the topic + consumer will need to handle like 750KiB/s. We would like room to grow, however, and other services can also write into this topic eventually.

In addition to scaling up topics, we also have the option of applying sampling on the `record_id` column before producing to Kafka. The `sample_rate` that was in effect at the time a record was emitted is included in the record so that we can account for changing sample rates later on when computing aggregates.